### PR TITLE
feat: WebSocket streaming + expanded models for TTS Next demo

### DIFF
--- a/slng-tts-next/.gitignore
+++ b/slng-tts-next/.gitignore
@@ -1,0 +1,2 @@
+.vercel
+.env*.local

--- a/slng-tts-next/app/components/CodeBlock.tsx
+++ b/slng-tts-next/app/components/CodeBlock.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { Highlight, themes } from "prism-react-renderer";
+
+type CodeBlockProps = {
+  code: string;
+  language: string;
+  title?: string;
+  wide?: boolean;
+};
+
+export function CodeBlock({ code, language, title, wide }: CodeBlockProps) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(code);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className={`code-card ${wide ? "wide" : ""}`}>
+      <div className="code-card-header">
+        {title && <h3>{title}</h3>}
+        <button
+          type="button"
+          className="copy-btn"
+          onClick={handleCopy}
+        >
+          {copied ? "Copied!" : "Copy"}
+        </button>
+      </div>
+      <Highlight theme={themes.nightOwl} code={code.trim()} language={language}>
+        {({ style, tokens, getLineProps, getTokenProps }) => (
+          <pre style={{ ...style, margin: 0, padding: "12px", borderRadius: "var(--radius)", fontSize: "0.75rem", lineHeight: 1.5, overflowX: "auto" }}>
+            {tokens.map((line, i) => (
+              <div key={i} {...getLineProps({ line })}>
+                {line.map((token, key) => (
+                  <span key={key} {...getTokenProps({ token })} />
+                ))}
+              </div>
+            ))}
+          </pre>
+        )}
+      </Highlight>
+    </div>
+  );
+}

--- a/slng-tts-next/app/components/LogConsole.tsx
+++ b/slng-tts-next/app/components/LogConsole.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState } from "react";
+import type { LogEntry } from "../hooks/useSessionLog";
+
+type LogConsoleProps = {
+  entries: LogEntry[];
+};
+
+export function LogConsole({ entries }: LogConsoleProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <div className="log-section">
+      <button
+        className={`log-toggle ${isOpen ? "open" : ""}`}
+        type="button"
+        onClick={() => setIsOpen((prev) => !prev)}
+      >
+        <span className="arrow">&#9654;</span> Log
+      </button>
+      <div className={`log ${isOpen ? "open" : ""}`}>
+        {entries.map((entry, i) => (
+          <div key={i}>
+            {entry.timestamp} {entry.message}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/slng-tts-next/app/components/ModeToggle.tsx
+++ b/slng-tts-next/app/components/ModeToggle.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+type ModeToggleProps = {
+  currentMode: "rest" | "websocket";
+  onModeChange: (mode: "rest" | "websocket") => void;
+};
+
+export function ModeToggle({ currentMode, onModeChange }: ModeToggleProps) {
+  return (
+    <div className="mode-toggle">
+      <button
+        type="button"
+        className={currentMode === "rest" ? "active" : ""}
+        onClick={() => onModeChange("rest")}
+      >
+        REST
+      </button>
+      <button
+        type="button"
+        className={currentMode === "websocket" ? "active" : ""}
+        onClick={() => onModeChange("websocket")}
+      >
+        WebSocket
+      </button>
+    </div>
+  );
+}

--- a/slng-tts-next/app/components/StatusBar.tsx
+++ b/slng-tts-next/app/components/StatusBar.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+type StatusBarProps = {
+  status: string;
+  isError: boolean;
+  isConnected: boolean;
+  isReady: boolean;
+};
+
+export function StatusBar({
+  status,
+  isError,
+  isConnected,
+  isReady,
+}: StatusBarProps) {
+  let barClass = "status-bar";
+  if (isError) {
+    barClass += " error";
+  } else if (isReady) {
+    barClass += " ready";
+  } else if (isConnected) {
+    barClass += " connected";
+  }
+
+  return (
+    <div className={barClass}>
+      <span className="status-dot" />
+      <span>{status}</span>
+    </div>
+  );
+}

--- a/slng-tts-next/app/components/WaveformCanvas.tsx
+++ b/slng-tts-next/app/components/WaveformCanvas.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+type WaveformCanvasProps = {
+  analyserNode: AnalyserNode | null;
+  isActive: boolean;
+};
+
+export function WaveformCanvas({
+  analyserNode,
+  isActive,
+}: WaveformCanvasProps) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const animIdRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    function resizeCanvas() {
+      const dpr = window.devicePixelRatio || 1;
+      const rect = canvas!.getBoundingClientRect();
+      canvas!.width = rect.width * dpr;
+      canvas!.height = rect.height * dpr;
+    }
+
+    function drawIdle() {
+      resizeCanvas();
+      const ctx = canvas!.getContext("2d");
+      if (!ctx) return;
+      const dpr = window.devicePixelRatio || 1;
+      const w = canvas!.width;
+      const h = canvas!.height;
+
+      ctx.clearRect(0, 0, w, h);
+      ctx.lineWidth = 2 * dpr;
+      ctx.strokeStyle = "rgba(202, 201, 196, 0.6)";
+      ctx.beginPath();
+      ctx.moveTo(0, h / 2);
+      ctx.lineTo(w, h / 2);
+      ctx.stroke();
+    }
+
+    function drawWaveform() {
+      if (!analyserNode) return;
+      const ctx = canvas!.getContext("2d");
+      if (!ctx) return;
+
+      const dpr = window.devicePixelRatio || 1;
+      const w = canvas!.width;
+      const h = canvas!.height;
+
+      const bufferLength = analyserNode.frequencyBinCount;
+      const dataArray = new Uint8Array(bufferLength);
+      analyserNode.getByteTimeDomainData(dataArray);
+
+      ctx.clearRect(0, 0, w, h);
+      ctx.lineWidth = 2.5 * dpr;
+      ctx.strokeStyle = "#fbe566";
+      ctx.beginPath();
+
+      const sliceWidth = w / bufferLength;
+      let x = 0;
+      for (let i = 0; i < bufferLength; i++) {
+        const v = dataArray[i] / 128.0;
+        const y = (v * h) / 2;
+        if (i === 0) {
+          ctx.moveTo(x, y);
+        } else {
+          ctx.lineTo(x, y);
+        }
+        x += sliceWidth;
+      }
+      ctx.lineTo(w, h / 2);
+      ctx.stroke();
+
+      animIdRef.current = requestAnimationFrame(drawWaveform);
+    }
+
+    if (isActive && analyserNode) {
+      resizeCanvas();
+      drawWaveform();
+    } else {
+      if (animIdRef.current) {
+        cancelAnimationFrame(animIdRef.current);
+        animIdRef.current = null;
+      }
+      drawIdle();
+    }
+
+    return () => {
+      if (animIdRef.current) {
+        cancelAnimationFrame(animIdRef.current);
+        animIdRef.current = null;
+      }
+    };
+  }, [analyserNode, isActive]);
+
+  return (
+    <div className="waveform-wrap">
+      <canvas ref={canvasRef} />
+    </div>
+  );
+}

--- a/slng-tts-next/app/globals.css
+++ b/slng-tts-next/app/globals.css
@@ -293,15 +293,105 @@ select:focus-visible {
   text-decoration: underline;
 }
 
-audio {
-  width: 100%;
+/* ── Mode toggle ── */
+.mode-toggle {
+  display: inline-flex;
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 3px;
+  gap: 2px;
+  margin-bottom: 20px;
+}
+
+.mode-toggle button {
+  padding: 7px 16px;
+  border-radius: 999px;
+  font-size: 0.82rem;
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  background: transparent;
+  color: var(--muted-foreground);
+  box-shadow: none;
+  transition: all 0.15s;
+  letter-spacing: 0.01em;
+}
+
+.mode-toggle button.active {
+  background: var(--card);
+  color: var(--foreground);
+  box-shadow: 0 1px 3px rgba(21, 18, 13, 0.1);
+}
+
+/* ── Model row ── */
+.model-row {
+  display: flex;
+  gap: 12px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.model-row .field {
+  flex: 1 1 280px;
+}
+
+.model-link {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: var(--foreground);
+  text-decoration: none;
+  margin-left: 8px;
+  opacity: 0.6;
+}
+
+.model-link:hover {
+  text-decoration: underline;
+  opacity: 1;
+}
+
+/* ── Connect row ── */
+.connect-row {
+  display: flex;
+  gap: 10px;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.connect-row .api-field {
+  flex: 1 1 280px;
+}
+
+.connect-row .btn-group {
+  display: flex;
+  gap: 8px;
+  flex-shrink: 0;
+  padding-bottom: 1px;
+}
+
+/* ── Secondary button ── */
+button.secondary {
+  background: var(--secondary);
+  color: var(--foreground);
+  border: 1px solid var(--border);
+  box-shadow: none;
+}
+
+/* ── Audio wrap ── */
+.audio-wrap {
   margin-top: 16px;
   padding: 8px 12px;
   border-radius: 999px;
   background: var(--secondary);
-  color: var(--secondary-foreground);
   border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
   box-shadow: 0 12px 24px rgba(21, 18, 13, 0.12);
+}
+
+.audio-wrap audio {
+  width: 100%;
+  display: block;
   accent-color: var(--accent);
 }
 
@@ -309,14 +399,178 @@ audio::-webkit-media-controls-panel {
   background: transparent;
 }
 
-.status {
-  margin-top: 12px;
-  font-size: 0.95rem;
+/* ── Waveform ── */
+.waveform-wrap {
+  margin-top: 16px;
+  border-radius: calc(var(--radius) * 2);
+  background: var(--secondary);
+  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  box-shadow: 0 12px 24px rgba(21, 18, 13, 0.12);
+  overflow: hidden;
+}
+
+.waveform-wrap canvas {
+  width: 100%;
+  height: 80px;
+  display: block;
+}
+
+/* ── Status bar ── */
+.status-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 14px;
+  padding: 8px 12px;
+  border-radius: var(--radius);
+  background: var(--secondary);
+  font-size: 0.85rem;
   color: var(--muted-foreground);
 }
 
-.status.error {
-  color: var(--destructive);
+.status-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--border);
+  flex-shrink: 0;
+}
+
+.status-bar.connected .status-dot {
+  background: var(--accent);
+}
+
+.status-bar.ready .status-dot {
+  background: var(--accent);
+  animation: pulse 1.8s ease-out infinite;
+}
+
+.status-bar.error .status-dot {
+  background: #ef4444;
+}
+
+.status-bar.error {
+  color: #ef4444;
+  background: #fef1f0;
+}
+
+/* ── Log console ── */
+.log-section {
+  margin-top: 12px;
+}
+
+.log-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.8rem;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  border: none;
+  background: none;
+  padding: 4px 0;
+  font-weight: 500;
+  box-shadow: none;
+}
+
+.log-toggle:hover {
+  color: var(--foreground);
+}
+
+.log-toggle:disabled {
+  background: none;
+}
+
+.log-toggle .arrow {
+  transition: transform 0.15s;
+  font-size: 0.7rem;
+}
+
+.log-toggle.open .arrow {
+  transform: rotate(90deg);
+}
+
+.log {
+  margin-top: 6px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  border: 1px solid var(--border);
+  background: var(--secondary);
+  font-size: 0.78rem;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  color: var(--muted-foreground);
+  max-height: 160px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  word-break: break-all;
+  display: none;
+}
+
+.log.open {
+  display: block;
+}
+
+/* ── Code samples ── */
+.code-samples {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 14px;
+  margin-top: 14px;
+}
+
+@media (min-width: 768px) {
+  .code-samples {
+    grid-template-columns: 1fr 1fr;
+  }
+  .code-card.wide {
+    grid-column: 1 / -1;
+  }
+}
+
+.code-card {
+  background: var(--secondary);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px;
+  overflow: hidden;
+}
+
+.code-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.code-card h3 {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted-foreground);
+  margin: 0;
+}
+
+.copy-btn {
+  font-size: 0.72rem;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--card);
+  color: var(--muted-foreground);
+  border: 1px solid var(--border);
+  box-shadow: none;
+  cursor: pointer;
+  font-weight: 500;
+  transition: color 0.15s, border-color 0.15s;
+}
+
+.copy-btn:hover {
+  color: var(--foreground);
+  border-color: var(--foreground);
+}
+
+/* ── Hidden utility ── */
+.hidden {
+  display: none !important;
 }
 
 details {

--- a/slng-tts-next/app/hooks/useAudioBuffer.ts
+++ b/slng-tts-next/app/hooks/useAudioBuffer.ts
@@ -1,0 +1,61 @@
+import { useCallback, useRef } from "react";
+
+export function useAudioBuffer() {
+  const chunksRef = useRef<Uint8Array[]>([]);
+  const bytesTotalRef = useRef(0);
+  const audioEndSeenRef = useRef(false);
+  const flushTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const reset = useCallback(() => {
+    chunksRef.current = [];
+    bytesTotalRef.current = 0;
+    audioEndSeenRef.current = false;
+    if (flushTimerRef.current) {
+      clearTimeout(flushTimerRef.current);
+      flushTimerRef.current = null;
+    }
+  }, []);
+
+  const appendChunk = useCallback((bytes: Uint8Array) => {
+    chunksRef.current.push(bytes);
+    bytesTotalRef.current += bytes.byteLength;
+  }, []);
+
+  const flush = useCallback((): Uint8Array | null => {
+    const chunks = chunksRef.current;
+    if (chunks.length === 0) return null;
+
+    const combined = new Uint8Array(bytesTotalRef.current);
+    let offset = 0;
+    for (const chunk of chunks) {
+      combined.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+
+    chunksRef.current = [];
+    bytesTotalRef.current = 0;
+    audioEndSeenRef.current = false;
+
+    return combined;
+  }, []);
+
+  const scheduleFlush = useCallback(
+    (onFlush: (bytes: Uint8Array) => void, force = false) => {
+      if (flushTimerRef.current) clearTimeout(flushTimerRef.current);
+      flushTimerRef.current = setTimeout(() => {
+        flushTimerRef.current = null;
+        if (audioEndSeenRef.current || force) {
+          const combined = flush();
+          if (combined) onFlush(combined);
+        }
+      }, 200);
+    },
+    [flush]
+  );
+
+  const markAudioEnd = useCallback(() => {
+    audioEndSeenRef.current = true;
+  }, []);
+
+  return { appendChunk, flush, reset, scheduleFlush, markAudioEnd };
+}

--- a/slng-tts-next/app/hooks/useSessionLog.ts
+++ b/slng-tts-next/app/hooks/useSessionLog.ts
@@ -1,0 +1,21 @@
+import { useCallback, useState } from "react";
+
+export type LogEntry = {
+  timestamp: string;
+  message: string;
+};
+
+export function useSessionLog() {
+  const [entries, setEntries] = useState<LogEntry[]>([]);
+
+  const appendLog = useCallback((message: string) => {
+    const timestamp = new Date().toLocaleTimeString();
+    setEntries((prev) => [{ timestamp, message }, ...prev]);
+  }, []);
+
+  const clearLog = useCallback(() => {
+    setEntries([]);
+  }, []);
+
+  return { entries, appendLog, clearLog };
+}

--- a/slng-tts-next/app/hooks/useWebAudio.ts
+++ b/slng-tts-next/app/hooks/useWebAudio.ts
@@ -1,0 +1,66 @@
+import { useCallback, useRef } from "react";
+import { pcmToFloat32 } from "../lib/audio-utils";
+
+export function useWebAudio(sampleRate: number) {
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const analyserNodeRef = useRef<AnalyserNode | null>(null);
+  const nextPlayTimeRef = useRef(0);
+
+  const ensureAudioContext = useCallback(() => {
+    if (!audioContextRef.current) {
+      audioContextRef.current = new AudioContext({ sampleRate });
+      const analyser = audioContextRef.current.createAnalyser();
+      analyser.fftSize = 256;
+      analyser.connect(audioContextRef.current.destination);
+      analyserNodeRef.current = analyser;
+    }
+    if (audioContextRef.current.state === "suspended") {
+      audioContextRef.current.resume();
+    }
+    return audioContextRef.current;
+  }, [sampleRate]);
+
+  const playPcmChunk = useCallback(
+    (bytes: Uint8Array) => {
+      const ctx = ensureAudioContext();
+      const float32 = pcmToFloat32(bytes);
+
+      const audioBuffer = ctx.createBuffer(1, float32.length, sampleRate);
+      audioBuffer.getChannelData(0).set(float32);
+
+      const source = ctx.createBufferSource();
+      source.buffer = audioBuffer;
+      source.connect(analyserNodeRef.current!);
+
+      const now = ctx.currentTime;
+      if (nextPlayTimeRef.current < now) {
+        nextPlayTimeRef.current = now + 0.05;
+      }
+
+      source.start(nextPlayTimeRef.current);
+      nextPlayTimeRef.current += float32.length / sampleRate;
+    },
+    [ensureAudioContext, sampleRate]
+  );
+
+  const closeAudio = useCallback(() => {
+    if (audioContextRef.current) {
+      audioContextRef.current.close();
+      audioContextRef.current = null;
+      analyserNodeRef.current = null;
+    }
+    nextPlayTimeRef.current = 0;
+  }, []);
+
+  const resetPlayTime = useCallback(() => {
+    nextPlayTimeRef.current = 0;
+  }, []);
+
+  return {
+    playPcmChunk,
+    closeAudio,
+    resetPlayTime,
+    analyserNodeRef,
+    ensureAudioContext,
+  };
+}

--- a/slng-tts-next/app/hooks/useWebSocket.ts
+++ b/slng-tts-next/app/hooks/useWebSocket.ts
@@ -1,0 +1,117 @@
+import { useCallback, useRef, useState } from "react";
+
+type WsCallbacks = {
+  onJsonMessage: (payload: Record<string, unknown>) => void;
+  onBinaryMessage: (data: ArrayBuffer) => void;
+  onLog: (message: string) => void;
+  onStatusChange: (message: string, isError?: boolean) => void;
+};
+
+export function useWebSocket(callbacks: WsCallbacks) {
+  const [isConnected, setIsConnected] = useState(false);
+  const [isReady, setIsReady] = useState(false);
+  const socketRef = useRef<WebSocket | null>(null);
+  const callbacksRef = useRef(callbacks);
+  callbacksRef.current = callbacks;
+
+  const disconnect = useCallback(() => {
+    if (socketRef.current) {
+      socketRef.current.close();
+      socketRef.current = null;
+    }
+    setIsReady(false);
+    setIsConnected(false);
+  }, []);
+
+  const connect = useCallback(
+    (options: {
+      wsUrl: string;
+      apiKey: string;
+      useProxy: boolean;
+      proxyUrl: string;
+      initMessage: string;
+    }) => {
+      const { wsUrl, apiKey, useProxy, proxyUrl, initMessage } = options;
+      const targetUrl = useProxy ? proxyUrl : wsUrl;
+
+      callbacksRef.current.onLog(`Connecting to ${targetUrl}`);
+      callbacksRef.current.onStatusChange("Connecting...");
+
+      const ws = new WebSocket(targetUrl);
+      ws.binaryType = "arraybuffer";
+      socketRef.current = ws;
+      setIsConnected(true);
+
+      ws.addEventListener("open", () => {
+        callbacksRef.current.onLog("WebSocket open. Sending init.");
+
+        if (useProxy) {
+          const envelope = JSON.stringify({ api_key: apiKey, target: wsUrl });
+          ws.send(envelope);
+        }
+
+        if (initMessage) {
+          ws.send(initMessage);
+        }
+
+        callbacksRef.current.onStatusChange("Connected. Waiting for ready...");
+      });
+
+      ws.addEventListener("message", (event) => {
+        if (typeof event.data === "string") {
+          callbacksRef.current.onLog(`Message: ${event.data}`);
+          try {
+            const payload = JSON.parse(event.data) as Record<string, unknown>;
+
+            const type = (payload.type as string)?.toLowerCase();
+            if (type === "metadata" || type === "ready") {
+              setIsReady(true);
+              callbacksRef.current.onStatusChange("Ready to send text.");
+            }
+
+            callbacksRef.current.onJsonMessage(payload);
+
+            if (payload.is_final) {
+              callbacksRef.current.onLog("Received final marker.");
+            }
+          } catch {
+            callbacksRef.current.onStatusChange(event.data);
+          }
+          return;
+        }
+
+        callbacksRef.current.onLog("Binary audio chunk received.");
+        callbacksRef.current.onBinaryMessage(event.data as ArrayBuffer);
+      });
+
+      ws.addEventListener("close", () => {
+        callbacksRef.current.onLog("WebSocket closed.");
+        callbacksRef.current.onStatusChange("Disconnected.");
+        setIsReady(false);
+        setIsConnected(false);
+        socketRef.current = null;
+      });
+
+      ws.addEventListener("error", () => {
+        callbacksRef.current.onStatusChange(
+          "WebSocket error. Check the log for details.",
+          true
+        );
+        callbacksRef.current.onLog("WebSocket error.");
+      });
+    },
+    []
+  );
+
+  const sendPayload = useCallback(
+    (payload: string, flushMessage: string) => {
+      const ws = socketRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) return;
+      ws.send(payload);
+      ws.send(flushMessage);
+    },
+    []
+  );
+
+  return { connect, disconnect, sendPayload, isConnected, isReady };
+}

--- a/slng-tts-next/app/lib/audio-utils.ts
+++ b/slng-tts-next/app/lib/audio-utils.ts
@@ -1,0 +1,62 @@
+export type AudioFormat = "mp3" | "wav" | "linear16";
+
+export function getAudioMimeType(format: AudioFormat): string {
+  if (format === "wav" || format === "linear16") {
+    return "audio/wav";
+  }
+  return "audio/mpeg";
+}
+
+export function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+export function pcmToFloat32(pcmBytes: Uint8Array): Float32Array {
+  const int16 = new Int16Array(
+    pcmBytes.buffer,
+    pcmBytes.byteOffset,
+    pcmBytes.byteLength / 2
+  );
+  const float32 = new Float32Array(int16.length);
+  for (let i = 0; i < int16.length; i++) {
+    float32[i] = int16[i] / 32768;
+  }
+  return float32;
+}
+
+export function pcmToWav(
+  pcmBytes: Uint8Array,
+  sampleRate: number,
+  channels: number
+): Uint8Array {
+  const bytesPerSample = 2;
+  const blockAlign = channels * bytesPerSample;
+  const byteRate = sampleRate * blockAlign;
+  const dataSize = pcmBytes.byteLength;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  function writeString(offset: number, value: string) {
+    for (let i = 0; i < value.length; i++) {
+      view.setUint8(offset + i, value.charCodeAt(i));
+    }
+  }
+
+  writeString(0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeString(8, "WAVE");
+  writeString(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, channels, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, byteRate, true);
+  view.setUint16(32, blockAlign, true);
+  view.setUint16(34, bytesPerSample * 8, true);
+  writeString(36, "data");
+  view.setUint32(40, dataSize, true);
+
+  new Uint8Array(buffer, 44).set(pcmBytes);
+  return new Uint8Array(buffer);
+}

--- a/slng-tts-next/app/lib/models.ts
+++ b/slng-tts-next/app/lib/models.ts
@@ -1,0 +1,293 @@
+export type ModelOption = {
+  value: string;
+  label: string;
+};
+
+export type ModelGroup = {
+  label: string;
+  options: ModelOption[];
+};
+
+export type VoiceOption = {
+  value: string;
+  label: string;
+};
+
+export type VoiceGroup = {
+  label: string;
+  options: VoiceOption[];
+};
+
+export type PromptSuggestion = {
+  label: string;
+  prompt: string;
+  model?: string;
+  voice?: string;
+};
+
+export const modelGroups: ModelGroup[] = [
+  {
+    label: "Deepgram",
+    options: [{ value: "deepgram/aura:2", label: "deepgram/aura:2" }],
+  },
+  {
+    label: "ElevenLabs",
+    options: [
+      { value: "elevenlabs/eleven:3", label: "elevenlabs/eleven:3" },
+      { value: "elevenlabs/eleven-flash:2", label: "elevenlabs/eleven-flash:2" },
+      { value: "elevenlabs/eleven-flash:2.5", label: "elevenlabs/eleven-flash:2.5" },
+      { value: "elevenlabs/eleven-multilingual:2", label: "elevenlabs/eleven-multilingual:2" },
+    ],
+  },
+  {
+    label: "Sarvam",
+    options: [{ value: "sarvam/bulbul:v3", label: "sarvam/bulbul:v3" }],
+  },
+  {
+    label: "SLNG / Deepgram",
+    options: [
+      { value: "slng/deepgram/aura:2", label: "slng/deepgram/aura:2" },
+      { value: "slng/deepgram/aura:2-en", label: "slng/deepgram/aura:2-en" },
+      { value: "slng/deepgram/aura:2-es", label: "slng/deepgram/aura:2-es" },
+    ],
+  },
+  {
+    label: "SLNG / Rime",
+    options: [
+      { value: "slng/rime/arcana:3-en", label: "slng/rime/arcana:3-en" },
+      { value: "slng/rime/arcana:3-es", label: "slng/rime/arcana:3-es" },
+      { value: "slng/rime/arcana:3-fr", label: "slng/rime/arcana:3-fr" },
+      { value: "slng/rime/arcana:3-hi", label: "slng/rime/arcana:3-hi" },
+      { value: "slng/rime/arcana:ar", label: "slng/rime/arcana:ar" },
+      { value: "slng/rime/arcana:de", label: "slng/rime/arcana:de" },
+      { value: "slng/rime/arcana:en", label: "slng/rime/arcana:en" },
+      { value: "slng/rime/arcana:es", label: "slng/rime/arcana:es" },
+      { value: "slng/rime/arcana:fr", label: "slng/rime/arcana:fr" },
+    ],
+  },
+  {
+    label: "Canopy Labs",
+    options: [{ value: "slng/canopylabs/orpheus:en", label: "slng/canopylabs/orpheus:en" }],
+  },
+];
+
+// ── Voice groups per provider ──
+
+const deepgramAuraVoices: VoiceGroup[] = [
+  {
+    label: "English",
+    options: [
+      { value: "aura-2-thalia-en", label: "Thalia (feminine)" },
+      { value: "aura-2-andromeda-en", label: "Andromeda (feminine)" },
+      { value: "aura-2-helena-en", label: "Helena (feminine)" },
+      { value: "aura-2-apollo-en", label: "Apollo (masculine)" },
+      { value: "aura-2-arcas-en", label: "Arcas (masculine)" },
+      { value: "aura-2-aries-en", label: "Aries (masculine)" },
+    ],
+  },
+  {
+    label: "Spanish",
+    options: [
+      { value: "aura-2-nestor-es", label: "Nestor (masculine)" },
+      { value: "aura-2-valentina-es", label: "Valentina (feminine)" },
+      { value: "aura-2-alvaro-es", label: "Alvaro (masculine)" },
+      { value: "aura-2-carina-es", label: "Carina (feminine)" },
+      { value: "aura-2-celeste-es", label: "Celeste (feminine)" },
+      { value: "aura-2-diana-es", label: "Diana (feminine)" },
+      { value: "aura-2-estrella-es", label: "Estrella (feminine)" },
+      { value: "aura-2-hector-es", label: "Hector (masculine)" },
+      { value: "aura-2-javier-es", label: "Javier (masculine)" },
+      { value: "aura-2-leon-es", label: "Leon (masculine)" },
+      { value: "aura-2-selena-es", label: "Selena (feminine)" },
+      { value: "aura-2-sirio-es", label: "Sirio (masculine)" },
+      { value: "aura-2-solana-es", label: "Solana (feminine)" },
+    ],
+  },
+];
+
+const rimeArcanaVoices: VoiceGroup[] = [
+  {
+    label: "English",
+    options: [
+      { value: "astra", label: "Astra (feminine)" },
+      { value: "luna", label: "Luna (feminine)" },
+      { value: "lyra", label: "Lyra (feminine)" },
+      { value: "celeste", label: "Celeste (feminine)" },
+      { value: "estelle", label: "Estelle (feminine)" },
+      { value: "vashti", label: "Vashti (feminine)" },
+      { value: "arcade", label: "Arcade (masculine)" },
+      { value: "albion", label: "Albion (masculine)" },
+      { value: "sirius", label: "Sirius (masculine)" },
+      { value: "bond", label: "Bond (masculine)" },
+      { value: "eliphas", label: "Eliphas (masculine)" },
+    ],
+  },
+  {
+    label: "Spanish",
+    options: [
+      { value: "aurelio", label: "Aurelio (masculine)" },
+      { value: "celestino", label: "Celestino (masculine)" },
+      { value: "lark", label: "Lark" },
+      { value: "luz", label: "Luz (feminine)" },
+      { value: "mar", label: "Mar" },
+      { value: "nova", label: "Nova (feminine)" },
+      { value: "pola", label: "Pola (feminine)" },
+      { value: "seraphina", label: "Seraphina (feminine)" },
+    ],
+  },
+  {
+    label: "French",
+    options: [
+      { value: "amarante", label: "Amarante (feminine)" },
+      { value: "aurelie", label: "Aurelie (feminine)" },
+      { value: "destin", label: "Destin (masculine)" },
+      { value: "morel_marianne", label: "Morel Marianne (feminine)" },
+      { value: "solstice", label: "Solstice (feminine)" },
+    ],
+  },
+  {
+    label: "Hindi",
+    options: [
+      { value: "anaya", label: "Anaya (feminine)" },
+      { value: "anil", label: "Anil (masculine)" },
+      { value: "arya", label: "Arya (feminine)" },
+    ],
+  },
+  {
+    label: "German",
+    options: [
+      { value: "alfhild", label: "Alfhild (feminine)" },
+      { value: "baldur", label: "Baldur (masculine)" },
+      { value: "kumara", label: "Kumara" },
+      { value: "liesel", label: "Liesel (feminine)" },
+      { value: "lorelei", label: "Lorelei (feminine)" },
+      { value: "runa", label: "Runa (feminine)" },
+    ],
+  },
+  {
+    label: "Arabic",
+    options: [
+      { value: "batin", label: "Batin (masculine)" },
+      { value: "layla", label: "Layla (feminine)" },
+      { value: "qadir", label: "Qadir (masculine)" },
+      { value: "sakina", label: "Sakina (feminine)" },
+    ],
+  },
+];
+
+const elevenlabsVoices: VoiceGroup[] = [
+  {
+    label: "Default",
+    options: [
+      { value: "default", label: "Default voice" },
+    ],
+  },
+];
+
+const sarvamVoices: VoiceGroup[] = [
+  {
+    label: "Default",
+    options: [
+      { value: "default", label: "Default voice" },
+    ],
+  },
+];
+
+const canopyLabsVoices: VoiceGroup[] = [
+  {
+    label: "Default",
+    options: [
+      { value: "default", label: "Default voice" },
+    ],
+  },
+];
+
+/**
+ * Returns the voice groups appropriate for the given model,
+ * and the docs URL for that provider's voices.
+ */
+export function getVoicesForModel(model: string): {
+  groups: VoiceGroup[];
+  docsUrl: string;
+} {
+  if (model.includes("rime") || model.includes("arcana")) {
+    return {
+      groups: rimeArcanaVoices,
+      docsUrl: "https://docs.slng.ai/voices/rime-arcana",
+    };
+  }
+  if (model.includes("elevenlabs")) {
+    return {
+      groups: elevenlabsVoices,
+      docsUrl: "https://docs.slng.ai/voices",
+    };
+  }
+  if (model.includes("sarvam")) {
+    return {
+      groups: sarvamVoices,
+      docsUrl: "https://docs.slng.ai/voices",
+    };
+  }
+  if (model.includes("canopy") || model.includes("orpheus")) {
+    return {
+      groups: canopyLabsVoices,
+      docsUrl: "https://docs.slng.ai/voices",
+    };
+  }
+  // Default: Deepgram Aura
+  return {
+    groups: deepgramAuraVoices,
+    docsUrl: "https://docs.slng.ai/voices/deepgram-aura",
+  };
+}
+
+/**
+ * Returns the default voice for a given model.
+ */
+export function getDefaultVoiceForModel(model: string): string {
+  const { groups } = getVoicesForModel(model);
+  return groups[0]?.options[0]?.value ?? "";
+}
+
+export const promptSuggestions: PromptSuggestion[] = [
+  {
+    label: "Octopus facts",
+    prompt:
+      "The octopus has three hearts, nine brains, and blue blood. Two of its hearts pump blood to the gills, while the third pumps it to the rest of the body. When an octopus swims, the heart that delivers blood to the body actually stops beating, which is why these creatures prefer crawling to swimming \u2014 it\u2019s less exhausting.",
+    model: "slng/deepgram/aura:2",
+    voice: "aura-2-thalia-en",
+  },
+  {
+    label: "The Great Emu War",
+    prompt:
+      "In 1932, Australia lost a war against emus. The Royal Australian Artillery was deployed with Lewis guns to cull the emu population in Western Australia. Despite firing thousands of rounds, the emus proved surprisingly resilient and elusive. The military withdrew after a few weeks, and the emus were declared the winners of what became known as the Great Emu War.",
+    model: "slng/deepgram/aura:2",
+    voice: "aura-2-apollo-en",
+  },
+  {
+    label: "Immortal honey",
+    prompt:
+      "Honey never spoils. Archaeologists have found pots of honey in ancient Egyptian tombs that are over three thousand years old and still perfectly edible. Honey\u2019s longevity comes from its low moisture content and acidic pH, which create an inhospitable environment for bacteria and microorganisms.",
+    model: "slng/deepgram/aura:2",
+    voice: "aura-2-andromeda-en",
+  },
+  {
+    label: "Paella autentica",
+    prompt:
+      "Una pregunta para un amigo: la paella valenciana original no lleva ni pollo ni camarones. Se prepara con conejo, judias verdes, garrofon y caracoles. El azafran le da su color dorado caracteristico. Cada region de Espana tiene su propia version, pero los valencianos insisten en que solo la suya es autentica.",
+    model: "slng/deepgram/aura:2-es",
+    voice: "aura-2-nestor-es",
+  },
+  {
+    label: "Pirate tale",
+    prompt:
+      "Arrr matey! Gather round and hear the tale of Blackbeard, the most fearsome pirate to ever sail the seven seas. Edward Teach, as he was known before taking to piracy, would weave slow-burning fuses into his enormous black beard before battle, wreathing his face in smoke and flame. His terrifying appearance alone was often enough to make merchant ships surrender without a fight.",
+    model: "slng/deepgram/aura:2",
+    voice: "aura-2-arcas-en",
+  },
+];
+
+export const BRIDGES_BASE_URL = "wss://api.slng.ai/v1/bridges/unmute/tts/";
+export const REST_BASE_URL = "https://api.slng.ai/v1/bridges/unmute/tts/";
+export const DEFAULT_MODEL = "slng/deepgram/aura:2";
+export const DEFAULT_VOICE = "aura-2-thalia-en";

--- a/slng-tts-next/app/page.tsx
+++ b/slng-tts-next/app/page.tsx
@@ -1,101 +1,240 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
-
-type TtsPayload = {
-  model: string;
-  text: string;
-  language?: string;
-};
-
-const promptSuggestions = [
-  {
-    label: "Welcome onboard",
-    prompt:
-      "Welcome aboard, everyone. Please take your seats and enjoy a smooth, on-time departure.",
-  },
-  {
-    label: "Ahoy pirate",
-    prompt:
-      "Ahoy matey, hoist the colors and mind the tide; adventure waits beyond the fog.",
-  },
-  {
-    label: "Hablas espanol",
-    prompt:
-      "Una pregunta para un amigo: ¿tu paella lleva pollo, camaron o ambos?",
-    model: "slng/deepgram/aura:2-es",
-    voice: "aura-2-nestor-es",
-  },
-];
-
-const modelOptions = [
-  { value: "slng/deepgram/aura:2-en", label: "slng/deepgram/aura:2-en (default)" },
-  { value: "slng/deepgram/aura:2-es", label: "slng/deepgram/aura:2-es" },
-  { value: "deepgram/aura:2", label: "deepgram/aura:2" },
-];
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ModeToggle } from "./components/ModeToggle";
+import { StatusBar } from "./components/StatusBar";
+import { WaveformCanvas } from "./components/WaveformCanvas";
+import { LogConsole } from "./components/LogConsole";
+import { CodeBlock } from "./components/CodeBlock";
+import { useSessionLog } from "./hooks/useSessionLog";
+import { useAudioBuffer } from "./hooks/useAudioBuffer";
+import { useWebAudio } from "./hooks/useWebAudio";
+import { useWebSocket } from "./hooks/useWebSocket";
+import {
+  modelGroups,
+  promptSuggestions,
+  getVoicesForModel,
+  getDefaultVoiceForModel,
+  BRIDGES_BASE_URL,
+  REST_BASE_URL,
+  DEFAULT_MODEL,
+  DEFAULT_VOICE,
+} from "./lib/models";
+import {
+  type AudioFormat,
+  getAudioMimeType,
+  base64ToBytes,
+  pcmToWav,
+} from "./lib/audio-utils";
 
 export default function Home() {
-  const [text, setText] = useState("Hello my friend, this is just a test.");
+  // ── Mode ──
+  const [currentMode, setCurrentMode] = useState<"rest" | "websocket">("rest");
+
+  // ── Shared state ──
+  const [text, setText] = useState(
+    "The octopus has three hearts, nine brains, and blue blood. Two of its hearts pump blood to the gills, while the third pumps it to the rest of the body. When an octopus swims, the heart that delivers blood to the body actually stops beating, which is why these creatures prefer crawling to swimming — it's less exhausting."
+  );
   const [apiKey, setApiKey] = useState("");
-  const [baseUrl, setBaseUrl] = useState("https://api.slng.ai");
-  const [model, setModel] = useState("slng/deepgram/aura:2-en");
-  const [voice, setVoice] = useState("aura-2-thalia-en");
-  const [language, setLanguage] = useState("");
-  const [status, setStatus] = useState("");
+  const [model, setModel] = useState(DEFAULT_MODEL);
+  const [voice, setVoice] = useState(DEFAULT_VOICE);
+  const [status, setStatus] = useState("Enter your API key and press Say it.");
   const [statusIsError, setStatusIsError] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [waveformActive, setWaveformActive] = useState(false);
 
+  // ── Dynamic voice groups based on model ──
+  const { groups: voiceGroups, docsUrl: voiceDocsUrl } = useMemo(
+    () => getVoicesForModel(model),
+    [model]
+  );
+
+  // Auto-switch voice when model changes to a different provider
+  useEffect(() => {
+    const allVoiceValues = voiceGroups.flatMap((g) =>
+      g.options.map((o) => o.value)
+    );
+    if (!allVoiceValues.includes(voice)) {
+      setVoice(getDefaultVoiceForModel(model));
+    }
+  }, [model, voiceGroups, voice]);
+
+  // ── WebSocket settings ──
+  const [wsUrl, setWsUrl] = useState(BRIDGES_BASE_URL + DEFAULT_MODEL);
+  const [proxyUrl, setProxyUrl] = useState("ws://localhost:8787");
+  const [useProxy, setUseProxy] = useState(true);
+  const [audioFormat, setAudioFormat] = useState<AudioFormat>("linear16");
+  const [sampleRate, setSampleRate] = useState("24000");
+  const [payloadMode, setPayloadMode] = useState<"text" | "custom">("text");
+  const [customPayload, setCustomPayload] = useState(
+    '{\n  "type": "text",\n  "text": "Hello from WebSocket!"\n}'
+  );
+  const [useCustomInit, setUseCustomInit] = useState(false);
+  const [customInitPayload, setCustomInitPayload] = useState(
+    `{\n  "type": "init",\n  "model": "${DEFAULT_MODEL}",\n  "voice": "${DEFAULT_VOICE}",\n  "config": {\n    "sample_rate": 24000,\n    "encoding": "linear16"\n  }\n}`
+  );
+
+  // ── Refs ──
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const textAreaRef = useRef<HTMLTextAreaElement | null>(null);
   const currentAudioUrlRef = useRef<string | null>(null);
+  const restAbortControllerRef = useRef<AbortController | null>(null);
 
-  const normalizedBaseUrl = useMemo(() => {
-    const value = baseUrl.trim();
-    return value ? value.replace(/\/+$/, "") : "";
-  }, [baseUrl]);
+  // ── Hooks ──
+  const { entries, appendLog } = useSessionLog();
+  const parsedSampleRate = useMemo(() => {
+    const v = parseInt(sampleRate, 10);
+    return Number.isFinite(v) && v > 0 ? v : 24000;
+  }, [sampleRate]);
+  const { playPcmChunk, closeAudio, resetPlayTime, analyserNodeRef, ensureAudioContext } =
+    useWebAudio(parsedSampleRate);
+  const { appendChunk, reset: resetAudioBuffer, scheduleFlush, markAudioEnd } =
+    useAudioBuffer();
 
-  const payload = useMemo<TtsPayload>(() => {
-    const trimmedText = text.trim();
-    const payloadData: TtsPayload = {
-      model,
-      text: trimmedText,
-    };
+  // ── Audio chunk base64 accumulator (for JSON-based audio) ──
+  const audioChunksBase64Ref = useRef("");
 
-    if (voice.trim()) {
-      payloadData.model = voice.trim();
-    }
-    if (language.trim()) {
-      payloadData.language = language.trim();
-    }
+  // ── Status helpers ──
+  const setStatusMessage = useCallback((message: string, isError = false) => {
+    setStatus(message);
+    setStatusIsError(isError);
+  }, []);
 
-    return payloadData;
-  }, [text, model, voice, language]);
+  // ── Audio helpers ──
+  const setAudioSource = useCallback(
+    (url: string, isObjectUrl = false) => {
+      if (currentAudioUrlRef.current) {
+        URL.revokeObjectURL(currentAudioUrlRef.current);
+      }
+      currentAudioUrlRef.current = isObjectUrl ? url : null;
+      if (audioRef.current) {
+        audioRef.current.src = url;
+        audioRef.current.play().catch(() => {
+          setStatusMessage("Audio ready. Press play to listen.");
+        });
+      }
+    },
+    [setStatusMessage]
+  );
 
-  const inspectEndpoint = useMemo(() => {
-    const inspectBase = normalizedBaseUrl || "https://api.slng.ai";
-    const inspectModel = model || "{model}";
-    return `${inspectBase}/v1/tts/${inspectModel}`;
-  }, [normalizedBaseUrl, model]);
+  const setAudioFromBytes = useCallback(
+    (bytes: Uint8Array, format: AudioFormat = "mp3") => {
+      const mimeType = getAudioMimeType(format);
+      const blob = new Blob([bytes.buffer as ArrayBuffer], { type: mimeType });
+      const objectUrl = URL.createObjectURL(blob);
+      setAudioSource(objectUrl, true);
+    },
+    [setAudioSource]
+  );
 
-  const curlPreview = useMemo(() => {
-    return `curl "${inspectEndpoint}" \\\n  -H "Authorization: Bearer $SLNG_API_KEY" \\\n  -H "Content-Type: application/json" \\\n  -d '${JSON.stringify(payload)}' \\\n  -o output_audio.wav`;
-  }, [inspectEndpoint, payload]);
+  // ── Flush handler for buffered audio ──
+  const handleBufferFlush = useCallback(
+    (combined: Uint8Array) => {
+      if (audioFormat === "linear16") {
+        const wav = pcmToWav(combined, parsedSampleRate, 1);
+        setAudioFromBytes(wav, "wav");
+      } else {
+        setAudioFromBytes(combined, audioFormat);
+      }
+    },
+    [audioFormat, parsedSampleRate, setAudioFromBytes]
+  );
 
+  // ── WebSocket callbacks ──
+  const handleJsonMessage = useCallback(
+    (payload: Record<string, unknown>) => {
+      if (
+        payload.type === "audio_end" ||
+        (payload.type as string)?.toLowerCase() === "flushed"
+      ) {
+        if (audioFormat === "linear16") {
+          appendLog("Stream flushed (streaming via Web Audio API).");
+          setWaveformActive(false);
+        } else {
+          markAudioEnd();
+          scheduleFlush(handleBufferFlush);
+        }
+      }
+
+      if (payload.message) {
+        setStatusMessage(payload.message as string);
+      }
+
+      if (payload.audio_url) {
+        setAudioSource(payload.audio_url as string);
+      }
+
+      if (payload.audio_base64 || payload.audio) {
+        audioChunksBase64Ref.current +=
+          (payload.audio_base64 as string) || (payload.audio as string) || "";
+      }
+
+      if (payload.is_final && audioChunksBase64Ref.current) {
+        const bytes = base64ToBytes(audioChunksBase64Ref.current);
+        setAudioFromBytes(bytes, audioFormat);
+        audioChunksBase64Ref.current = "";
+      }
+
+      if (
+        (payload.type === "chunk" || payload.type === "audio_chunk") &&
+        payload.data
+      ) {
+        const bytes = base64ToBytes(payload.data as string);
+        appendChunk(bytes);
+        scheduleFlush(handleBufferFlush, true);
+      }
+    },
+    [
+      audioFormat,
+      appendLog,
+      setStatusMessage,
+      setAudioSource,
+      setAudioFromBytes,
+      markAudioEnd,
+      scheduleFlush,
+      handleBufferFlush,
+      appendChunk,
+    ]
+  );
+
+  const handleBinaryMessage = useCallback(
+    (data: ArrayBuffer) => {
+      const bytes = new Uint8Array(data);
+      if (audioFormat === "linear16") {
+        playPcmChunk(bytes);
+        setWaveformActive(true);
+        return;
+      }
+      appendChunk(bytes);
+      scheduleFlush(handleBufferFlush);
+    },
+    [audioFormat, playPcmChunk, appendChunk, scheduleFlush, handleBufferFlush]
+  );
+
+  const {
+    connect,
+    disconnect,
+    sendPayload,
+    isConnected,
+    isReady,
+  } = useWebSocket({
+    onJsonMessage: handleJsonMessage,
+    onBinaryMessage: handleBinaryMessage,
+    onLog: appendLog,
+    onStatusChange: setStatusMessage,
+  });
+
+  // ── Audio player events ──
   useEffect(() => {
     const audio = audioRef.current;
-    if (!audio) {
-      return;
-    }
-
+    if (!audio) return;
     const handlePlay = () => setIsPlaying(true);
     const handlePause = () => setIsPlaying(false);
     const handleEnd = () => setIsPlaying(false);
-
     audio.addEventListener("play", handlePlay);
     audio.addEventListener("pause", handlePause);
     audio.addEventListener("ended", handleEnd);
-
     return () => {
       audio.removeEventListener("play", handlePlay);
       audio.removeEventListener("pause", handlePause);
@@ -103,6 +242,7 @@ export default function Home() {
     };
   }, []);
 
+  // ── Cleanup URL on unmount ──
   useEffect(() => {
     return () => {
       if (currentAudioUrlRef.current) {
@@ -111,110 +251,147 @@ export default function Home() {
     };
   }, []);
 
-  const setStatusMessage = (message: string, isError = false) => {
-    setStatus(message);
-    setStatusIsError(isError);
-  };
+  // ── Update WS URL when model changes ──
+  useEffect(() => {
+    setWsUrl(BRIDGES_BASE_URL + model);
+  }, [model]);
 
-  const setAudioSource = (url: string, isObjectUrl = false) => {
-    if (currentAudioUrlRef.current) {
-      URL.revokeObjectURL(currentAudioUrlRef.current);
-    }
-    currentAudioUrlRef.current = isObjectUrl ? url : null;
-
-    if (audioRef.current) {
-      audioRef.current.src = url;
-      audioRef.current.play().catch(() => {
-        setStatusMessage("Audio ready. Press play to listen.");
-      });
-    }
-  };
-
-  const setAudioFromBytes = (bytes: Uint8Array) => {
-    const audioBuffer = new Uint8Array(bytes).buffer;
-    const audioBlob = new Blob([audioBuffer]);
-    const objectUrl = URL.createObjectURL(audioBlob);
-    setAudioSource(objectUrl, true);
-  };
-
-  const handleSseResponse = async (response: Response) => {
-    if (!response.body) {
-      throw new Error("Streaming response body is not available.");
-    }
-
-    const reader = response.body.getReader();
-    const decoder = new TextDecoder();
-    let buffer = "";
-    let audioBase64 = "";
-    let gotAudio = false;
-
-    while (true) {
-      const { value, done } = await reader.read();
-      if (done) {
-        break;
+  // ── Mode switching ──
+  const handleModeChange = useCallback(
+    (mode: "rest" | "websocket") => {
+      if (mode === "rest" && isConnected) {
+        disconnect();
+        closeAudio();
       }
-      buffer += decoder.decode(value, { stream: true });
+      setCurrentMode(mode);
+      setWaveformActive(false);
+      if (mode === "rest") {
+        setStatusMessage("Enter your API key and press Say it.");
+      } else {
+        setStatusMessage("Enter your API key and connect.");
+      }
+    },
+    [isConnected, disconnect, closeAudio, setStatusMessage]
+  );
 
-      const chunks = buffer.split("\n\n");
-      buffer = chunks.pop() || "";
+  // ── Connect / Disconnect ──
+  const handleConnect = useCallback(() => {
+    if (isConnected) {
+      disconnect();
+      closeAudio();
+      setWaveformActive(false);
+      return;
+    }
 
-      for (const chunk of chunks) {
-        const lines = chunk.split("\n");
-        const dataLines = lines
-          .filter((line) => line.startsWith("data:"))
-          .map((line) => line.slice(5).trimStart());
+    if (!apiKey.trim()) {
+      setStatusMessage("Enter your SLNG API key.", true);
+      return;
+    }
+    if (!wsUrl.trim()) {
+      setStatusMessage("Enter a WebSocket URL.", true);
+      return;
+    }
+    if (useProxy && !proxyUrl.trim()) {
+      setStatusMessage("Enter the proxy WebSocket URL.", true);
+      return;
+    }
 
-        if (dataLines.length === 0) {
-          continue;
-        }
+    ensureAudioContext();
+    audioChunksBase64Ref.current = "";
+    resetAudioBuffer();
+    resetPlayTime();
 
-        const data = dataLines.join("\n").trim();
-        if (!data) {
-          continue;
-        }
-        if (data === "[DONE]" || data === "[done]") {
-          return gotAudio;
-        }
+    const initMessage = useCustomInit
+      ? customInitPayload.trim()
+      : JSON.stringify({
+          type: "init",
+          model,
+          voice,
+          config: { sample_rate: parsedSampleRate, encoding: audioFormat },
+        });
 
-        try {
-          const payload = JSON.parse(data) as {
-            message?: string;
-            audio_url?: string;
-            audio_base64?: string;
-            audio?: string;
-            is_final?: boolean;
-          };
-          if (payload.message) {
-            setStatusMessage(payload.message);
-          }
-          if (payload.audio_url) {
-            setAudioSource(payload.audio_url);
-            gotAudio = true;
-          }
-          if (payload.audio_base64 || payload.audio) {
-            audioBase64 += payload.audio_base64 || payload.audio || "";
-            gotAudio = true;
-          }
-          if (payload.is_final) {
-            break;
-          }
-        } catch {
-          setStatusMessage(data);
-        }
+    connect({
+      wsUrl: wsUrl.trim(),
+      apiKey: apiKey.trim(),
+      useProxy,
+      proxyUrl: proxyUrl.trim(),
+      initMessage,
+    });
+  }, [
+    isConnected,
+    disconnect,
+    closeAudio,
+    apiKey,
+    wsUrl,
+    useProxy,
+    proxyUrl,
+    ensureAudioContext,
+    resetAudioBuffer,
+    resetPlayTime,
+    useCustomInit,
+    customInitPayload,
+    model,
+    voice,
+    parsedSampleRate,
+    audioFormat,
+    connect,
+    setStatusMessage,
+  ]);
+
+  // ── Send WS payload ──
+  const handleWsSend = useCallback(() => {
+    if (!isReady) {
+      setStatusMessage("Waiting for ready signal.", true);
+      return;
+    }
+
+    const trimmedText = text.trim();
+    const payload =
+      payloadMode === "custom"
+        ? customPayload.trim()
+        : JSON.stringify({ type: "text", text: trimmedText });
+
+    if (payloadMode !== "custom" && !trimmedText) {
+      setStatusMessage("Enter some text to synthesize.", true);
+      return;
+    }
+
+    if (payloadMode === "custom") {
+      if (!payload) {
+        setStatusMessage("Enter custom JSON payload.", true);
+        return;
+      }
+      try {
+        JSON.parse(payload);
+      } catch (e) {
+        setStatusMessage(
+          `Invalid payload JSON: ${(e as Error).message}`,
+          true
+        );
+        return;
       }
     }
 
-    if (audioBase64) {
-      const binary = atob(audioBase64);
-      const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
-      setAudioFromBytes(bytes);
-      gotAudio = true;
-    }
+    appendLog(`Sending payload: ${payload}`);
+    resetAudioBuffer();
+    resetPlayTime();
+    setWaveformActive(false);
+    sendPayload(payload, JSON.stringify({ type: "flush" }));
+    setStatusMessage("Payload sent. Waiting for audio...");
+  }, [
+    isReady,
+    text,
+    payloadMode,
+    customPayload,
+    appendLog,
+    resetAudioBuffer,
+    resetPlayTime,
+    sendPayload,
+    setStatusMessage,
+  ]);
 
-    return gotAudio;
-  };
-
-  const generateAudio = async () => {
+  // ── REST request ──
+  const generateAudio = useCallback(async () => {
     if (!apiKey.trim()) {
       setStatusMessage("Enter your SLNG API key.", true);
       return;
@@ -223,59 +400,108 @@ export default function Home() {
       setStatusMessage("Enter some text to synthesize.", true);
       return;
     }
-    if (!normalizedBaseUrl) {
-      setStatusMessage("Enter a base URL.", true);
-      return;
-    }
     if (!model.trim()) {
       setStatusMessage("Select a model.", true);
       return;
     }
 
+    if (restAbortControllerRef.current) restAbortControllerRef.current.abort();
+    restAbortControllerRef.current = new AbortController();
+
     setStatusMessage("");
     setIsBusy(true);
 
-    try {
-      const endpoint = `${normalizedBaseUrl}/v1/tts/${model}`;
-      setStatusMessage(`Calling ${endpoint}`);
+    const url = REST_BASE_URL + model;
+    const body: Record<string, string> = { model, text: text.trim() };
+    if (voice) body.voice = voice;
 
-      const response = await fetch(endpoint, {
+    appendLog(`REST POST ${url}`);
+
+    try {
+      const response = await fetch(url, {
         method: "POST",
         headers: {
           Authorization: `Bearer ${apiKey.trim()}`,
-          Accept: "text/event-stream",
           "Content-Type": "application/json",
         },
-        body: JSON.stringify(payload),
+        body: JSON.stringify(body),
+        signal: restAbortControllerRef.current.signal,
       });
 
       if (!response.ok) {
-        const errorBody = await response.text();
-        throw new Error(`API error ${response.status}: ${errorBody}`);
+        const errorText = await response.text();
+        setStatusMessage(`Error ${response.status}: ${errorText}`, true);
+        appendLog(`REST error: ${response.status} ${errorText}`);
+        return;
       }
 
       const contentType = response.headers.get("content-type") || "";
-      if (contentType.includes("text/event-stream")) {
-        setStatusMessage("Streaming audio...");
-        const gotAudio = await handleSseResponse(response);
-        if (!gotAudio) {
-          setStatusMessage("Stream ended without audio.", true);
-        }
-      } else {
-        const audioBlob = await response.blob();
-        const objectUrl = URL.createObjectURL(audioBlob);
-        setAudioSource(objectUrl, true);
+      appendLog(`Response content-type: ${contentType}`);
+
+      const blob = await response.blob();
+      if (currentAudioUrlRef.current) {
+        URL.revokeObjectURL(currentAudioUrlRef.current);
       }
+      currentAudioUrlRef.current = URL.createObjectURL(blob);
+      if (audioRef.current) {
+        audioRef.current.src = currentAudioUrlRef.current;
+        audioRef.current.play().catch(() => {
+          setStatusMessage("Audio ready. Press play to listen.");
+        });
+      }
+
+      setStatusMessage("Audio received.");
+      appendLog(`Audio received: ${(blob.size / 1024).toFixed(1)} KB`);
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to generate audio.";
-      setStatusMessage(message, true);
+      if ((error as Error).name === "AbortError") return;
+      setStatusMessage(
+        `Request failed: ${(error as Error).message}`,
+        true
+      );
+      appendLog(`REST error: ${(error as Error).message}`);
     } finally {
       setIsBusy(false);
+      restAbortControllerRef.current = null;
     }
-  };
+  }, [apiKey, text, model, voice, appendLog, setStatusMessage]);
 
+  // ── Send button handler ──
+  const handleSend = useCallback(() => {
+    if (currentMode === "rest") {
+      generateAudio();
+    } else {
+      handleWsSend();
+    }
+  }, [currentMode, generateAudio, handleWsSend]);
+
+  // ── Chip click ──
+  const handleChipClick = useCallback(
+    (suggestion: (typeof promptSuggestions)[number]) => {
+      setText(suggestion.prompt);
+      if (suggestion.model) setModel(suggestion.model);
+      if (suggestion.voice) setVoice(suggestion.voice);
+      textAreaRef.current?.focus();
+    },
+    []
+  );
+
+  // ── Computed ──
+  const isWs = currentMode === "websocket";
   const isMissingApiKey = apiKey.trim().length === 0;
-  const isSpeakDisabled = isBusy || isMissingApiKey;
+  const isSendDisabled = isWs
+    ? !isReady
+    : isBusy || isMissingApiKey;
+
+  const restPayload = useMemo(() => {
+    const p: Record<string, string> = { model, text: text.trim() };
+    if (voice) p.voice = voice;
+    return p;
+  }, [model, text, voice]);
+
+  const curlPreview = useMemo(() => {
+    const url = REST_BASE_URL + model;
+    return `curl "${url}" \\\n  -H "Authorization: Bearer $SLNG_API_KEY" \\\n  -H "Content-Type: application/json" \\\n  -d '${JSON.stringify(restPayload)}' \\\n  --output speech.wav`;
+  }, [model, restPayload]);
 
   return (
     <div className="page">
@@ -298,145 +524,424 @@ export default function Home() {
         <h1>SLNG TTS Demo</h1>
         <p>Type something and hear it instantly.</p>
 
+        <ModeToggle currentMode={currentMode} onModeChange={handleModeChange} />
+
+        <label htmlFor="textInput">Text to synthesize</label>
         <textarea
+          id="textInput"
           ref={textAreaRef}
           value={text}
-          onChange={(event) => setText(event.target.value)}
+          onChange={(e) => setText(e.target.value)}
           placeholder="Try: Welcome to SLNG."
         />
+
         <div className="prompt-chips">
           {promptSuggestions.map((suggestion) => (
             <button
-              key={suggestion.prompt}
+              key={suggestion.label}
               className="chip"
               type="button"
-              onClick={() => {
-                setText(suggestion.prompt);
-                if (suggestion.model) {
-                  setModel(suggestion.model);
-                }
-                if (suggestion.voice) {
-                  setVoice(suggestion.voice);
-                }
-                textAreaRef.current?.focus();
-              }}
+              onClick={() => handleChipClick(suggestion)}
             >
               {suggestion.label}
             </button>
           ))}
         </div>
 
-        <div className="row">
-          <input
-            type="password"
-            placeholder="Paste your SLNG API key"
-            autoComplete="off"
-            value={apiKey}
-            onChange={(event) => setApiKey(event.target.value)}
-          />
-          <button
-            className={`hero-button ${isBusy ? "is-loading" : ""} ${
-              isMissingApiKey ? "is-disabled" : ""
-            }`}
-            onClick={generateAudio}
-            disabled={isSpeakDisabled}
-            data-default-text="Speak"
-            data-loading-text="Generating..."
-          >
-            <span className="pulse" aria-hidden="true"></span>
-            {isBusy ? "Generating..." : "Speak"}
-          </button>
+        {/* Model / Voice selectors */}
+        <div className="model-row">
+          <div className="field">
+            <label htmlFor="modelSelect">
+              Model
+              <a
+                className="model-link"
+                href="https://docs.slng.ai/models"
+                target="_blank"
+                rel="noopener"
+              >
+                Discover models &rarr;
+              </a>
+            </label>
+            <select
+              id="modelSelect"
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+            >
+              {modelGroups.map((group) => (
+                <optgroup key={group.label} label={group.label}>
+                  {group.options.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+          </div>
+          <div className="field">
+            <label htmlFor="voiceSelect">
+              Voice
+              <a
+                className="model-link"
+                href={voiceDocsUrl}
+                target="_blank"
+                rel="noopener"
+              >
+                Discover voices &rarr;
+              </a>
+            </label>
+            <select
+              id="voiceSelect"
+              value={voice}
+              onChange={(e) => setVoice(e.target.value)}
+            >
+              {voiceGroups.map((group) => (
+                <optgroup key={group.label} label={group.label}>
+                  {group.options.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </optgroup>
+              ))}
+            </select>
+          </div>
         </div>
-        <a
-          className="cta-link"
-          href="https://slng.ai?utm_source=slng-demo&utm_medium=example&utm_campaign=tts"
-        >
-          Get API key
-        </a>
 
+        {/* Connect row */}
+        <div className="connect-row">
+          <div className="api-field">
+            <label htmlFor="apiKeyInput">
+              API Key
+              <a
+                className="model-link"
+                href="https://app.slng.ai"
+                target="_blank"
+                rel="noopener"
+              >
+                Get API key &rarr;
+              </a>
+            </label>
+            <input
+              id="apiKeyInput"
+              type="password"
+              placeholder="Paste your SLNG API key"
+              autoComplete="off"
+              value={apiKey}
+              onChange={(e) => setApiKey(e.target.value)}
+            />
+          </div>
+          <div className="btn-group">
+            {isWs && (
+              <button
+                type="button"
+                className={`secondary ${isConnected ? "" : ""}`}
+                onClick={handleConnect}
+              >
+                {isConnected ? "Disconnect" : "Connect"}
+              </button>
+            )}
+            <button
+              type="button"
+              className={`hero-button ${isBusy ? "is-loading" : ""} ${
+                isSendDisabled ? "is-disabled" : ""
+              }`}
+              onClick={handleSend}
+              disabled={isSendDisabled}
+            >
+              <span className="pulse" aria-hidden="true"></span>
+              {isBusy ? "Generating..." : "Say it"}
+            </button>
+          </div>
+        </div>
+
+        {/* Status bar */}
+        <StatusBar
+          status={status}
+          isError={statusIsError}
+          isConnected={isConnected}
+          isReady={isReady}
+        />
+
+        {/* REST: audio player */}
+        {!isWs && (
+          <div className="audio-wrap">
+            <audio ref={audioRef} controls />
+          </div>
+        )}
+
+        {/* WebSocket: waveform canvas */}
+        {isWs && (
+          <WaveformCanvas
+            analyserNode={analyserNodeRef.current}
+            isActive={waveformActive}
+          />
+        )}
+
+        {/* Log console */}
+        <LogConsole entries={entries} />
+
+        {/* How to implement — mode-aware */}
         <details>
-          <summary>Advanced settings</summary>
-          <label htmlFor="baseUrl">Base URL</label>
-          <input
-            id="baseUrl"
-            type="text"
-            value={baseUrl}
-            onChange={(event) => setBaseUrl(event.target.value)}
-          />
+          <summary>How to implement</summary>
+          <div className="code-samples">
+            {!isWs && (
+              <>
+                <CodeBlock
+                  title="Request payload"
+                  language="json"
+                  code={JSON.stringify(restPayload, null, 2)}
+                />
+                <CodeBlock
+                  title="cURL"
+                  language="bash"
+                  code={curlPreview}
+                />
+                <CodeBlock
+                  title="JavaScript"
+                  language="javascript"
+                  wide
+                  code={`const MODEL = "${model}";
+const VOICE = "${voice}";
+const API_KEY = "YOUR_API_KEY";
 
-          <label htmlFor="modelSelect">Model</label>
-          <select
-            id="modelSelect"
-            value={model}
-            onChange={(event) => setModel(event.target.value)}
-          >
-            {modelOptions.map((option) => (
-              <option key={option.value} value={option.value}>
-                {option.label}
-              </option>
-            ))}
-          </select>
+const res = await fetch(
+  "${REST_BASE_URL}" + MODEL,
+  {
+    method: "POST",
+    headers: {
+      "Authorization": "Bearer " + API_KEY,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: VOICE,
+      text: "Hello world",
+    }),
+  }
+);
 
-          <div className="row">
-            <div>
-              <label htmlFor="voiceInput">Voice</label>
-              <input
-                id="voiceInput"
-                type="text"
-                placeholder="e.g. aura-2-thalia-en"
-                value={voice}
-                onChange={(event) => setVoice(event.target.value)}
+// Get audio blob and play it
+const blob = await res.blob();
+const audio = new Audio(URL.createObjectURL(blob));
+audio.play();`}
+                />
+              </>
+            )}
+            {isWs && (
+              <CodeBlock
+                title="WebSocket — Streaming"
+                language="javascript"
+                wide
+                code={`const MODEL = "${model}";
+const VOICE = "${voice}";
+const SAMPLE_RATE = ${parsedSampleRate};
+const ENCODING = "${audioFormat}";
+
+// Set up Web Audio API for gapless PCM playback
+const audioCtx = new AudioContext({ sampleRate: SAMPLE_RATE });
+let nextPlayTime = 0;
+
+function playPcmChunk(pcmBytes) {
+  // Convert Int16 PCM to Float32 for Web Audio API
+  const int16 = new Int16Array(pcmBytes.buffer);
+  const float32 = new Float32Array(int16.length);
+  for (let i = 0; i < int16.length; i++) {
+    float32[i] = int16[i] / 32768;
+  }
+
+  const buffer = audioCtx.createBuffer(1, float32.length, SAMPLE_RATE);
+  buffer.getChannelData(0).set(float32);
+
+  const source = audioCtx.createBufferSource();
+  source.buffer = buffer;
+  source.connect(audioCtx.destination);
+
+  // Schedule gapless playback
+  const now = audioCtx.currentTime;
+  if (nextPlayTime < now) nextPlayTime = now + 0.05;
+  source.start(nextPlayTime);
+  nextPlayTime += float32.length / SAMPLE_RATE;
+}
+
+// Connect to WebSocket
+const ws = new WebSocket("${BRIDGES_BASE_URL}" + MODEL);
+ws.binaryType = "arraybuffer";
+
+ws.onopen = () => {
+  // 1. Initialize the session
+  ws.send(JSON.stringify({
+    type: "init",
+    model: MODEL,
+    voice: VOICE,
+    config: { sample_rate: SAMPLE_RATE, encoding: ENCODING },
+  }));
+};
+
+ws.onmessage = (event) => {
+  if (event.data instanceof ArrayBuffer) {
+    // 3. Receive binary PCM chunks and play them
+    playPcmChunk(new Uint8Array(event.data));
+  } else {
+    const msg = JSON.parse(event.data);
+    if (msg.type === "ready") {
+      // 2. Send text once session is ready
+      ws.send(JSON.stringify({ type: "text", text: "Hello world" }));
+      ws.send(JSON.stringify({ type: "flush" }));
+    }
+  }
+};`}
               />
-            </div>
-            <div>
-              <label htmlFor="languageInput">Language</label>
-              <input
-                id="languageInput"
-                type="text"
-                placeholder="e.g. es"
-                value={language}
-                onChange={(event) => setLanguage(event.target.value)}
-              />
-            </div>
+            )}
           </div>
         </details>
 
-        <audio ref={audioRef} controls></audio>
-        <div className={`status ${statusIsError ? "error" : ""}`}>
-          {status}
-        </div>
+        {/* Advanced settings (WS only) */}
+        {isWs && (
+          <details>
+            <summary>Advanced settings</summary>
+            <label htmlFor="wsUrlInput" style={{ marginTop: 12 }}>
+              WebSocket URL
+            </label>
+            <input
+              id="wsUrlInput"
+              type="text"
+              value={wsUrl}
+              onChange={(e) => setWsUrl(e.target.value)}
+            />
 
-        <details className="inspect">
-          <summary>Show how this works</summary>
-          <div className="inspect-grid">
-            <div className="inspect-card">
-              <h3>Request payload</h3>
-              <pre>{JSON.stringify(payload, null, 2)}</pre>
+            <div className="row">
+              <div>
+                <label htmlFor="proxyUrlInput">Proxy WebSocket URL</label>
+                <input
+                  id="proxyUrlInput"
+                  type="text"
+                  value={proxyUrl}
+                  onChange={(e) => setProxyUrl(e.target.value)}
+                />
+              </div>
+              <div style={{ flex: "0 0 180px", alignSelf: "flex-end" }}>
+                <label
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={useProxy}
+                    onChange={(e) => setUseProxy(e.target.checked)}
+                  />
+                  Use proxy
+                </label>
+              </div>
             </div>
-            <div className="inspect-card">
-              <h3>cURL</h3>
-              <pre>{curlPreview}</pre>
+
+            <div className="row">
+              <div>
+                <label htmlFor="payloadMode">Payload mode</label>
+                <select
+                  id="payloadMode"
+                  value={payloadMode}
+                  onChange={(e) =>
+                    setPayloadMode(e.target.value as "text" | "custom")
+                  }
+                >
+                  <option value="text">{`{"text":"..."}`}</option>
+                  <option value="custom">Raw JSON (below)</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="audioFormat">Audio format</label>
+                <select
+                  id="audioFormat"
+                  value={audioFormat}
+                  onChange={(e) =>
+                    setAudioFormat(e.target.value as AudioFormat)
+                  }
+                >
+                  <option value="mp3">MP3</option>
+                  <option value="wav">WAV</option>
+                  <option value="linear16">Linear16 (PCM)</option>
+                </select>
+              </div>
+              <div>
+                <label htmlFor="sampleRateInput">Sample rate (PCM)</label>
+                <input
+                  id="sampleRateInput"
+                  type="text"
+                  value={sampleRate}
+                  inputMode="numeric"
+                  onChange={(e) => setSampleRate(e.target.value)}
+                />
+              </div>
             </div>
-          </div>
-        </details>
+
+            <label htmlFor="customPayload" style={{ marginTop: 12 }}>
+              Custom JSON payload
+            </label>
+            <textarea
+              id="customPayload"
+              rows={4}
+              spellCheck={false}
+              value={customPayload}
+              onChange={(e) => setCustomPayload(e.target.value)}
+            />
+
+            <div className="row">
+              <div style={{ flex: "0 0 180px", alignSelf: "flex-end" }}>
+                <label
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                  }}
+                >
+                  <input
+                    type="checkbox"
+                    checked={useCustomInit}
+                    onChange={(e) => setUseCustomInit(e.target.checked)}
+                  />
+                  Use custom init
+                </label>
+              </div>
+            </div>
+
+            <label htmlFor="customInitPayload" style={{ marginTop: 12 }}>
+              Custom init JSON
+            </label>
+            <textarea
+              id="customInitPayload"
+              rows={4}
+              spellCheck={false}
+              value={customInitPayload}
+              onChange={(e) => setCustomInitPayload(e.target.value)}
+            />
+          </details>
+        )}
+
       </div>
 
       <footer className="page-footer">
         <div className="footer-stack">
           <p className="h100-saans-bold">Unmuted.</p>
-          <img
-            alt="Logo"
-            loading="lazy"
-            width={149}
-            height={49}
-            decoding="async"
-            style={{ color: "transparent" }}
-            src="https://www.datocms-assets.com/182222/1763142213-logo-lg.svg"
-          />
+          <a href="https://slng.ai" target="_blank" rel="noopener">
+            <img
+              alt="SLNG"
+              loading="lazy"
+              width={149}
+              height={49}
+              decoding="async"
+              style={{ color: "transparent" }}
+              src="https://www.datocms-assets.com/182222/1763142213-logo-lg.svg"
+            />
+          </a>
         </div>
         <a
           className="footer-link"
-          href="https://slng.ai?utm_source=slng-demo&utm_medium=example&utm_campaign=tts"
+          href="https://app.slng.ai"
+          target="_blank"
+          rel="noopener"
         >
           Create your API Key
         </a>

--- a/slng-tts-next/next-env.d.ts
+++ b/slng-tts-next/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/slng-tts-next/package-lock.json
+++ b/slng-tts-next/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "16.1.2",
+        "prism-react-renderer": "^2.4.1",
         "react": "19.2.3",
         "react-dom": "19.2.3"
       },
@@ -16,9 +17,12 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@types/ws": "^8.18.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.2",
-        "typescript": "^5"
+        "tsx": "^4.21.0",
+        "typescript": "^5",
+        "ws": "^8.19.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -52,7 +56,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -293,6 +296,448 @@
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
+      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
+      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
+      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
+      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
+      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
+      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
+      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
+      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
+      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
+      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
+      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
+      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
+      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
+      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
+      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
+      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
+      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
+      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
+      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
+      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
+      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
+      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
+      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1270,13 +1715,18 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/prismjs": {
+      "version": "1.26.6",
+      "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.6.tgz",
+      "integrity": "sha512-vqlvI7qlMvcCBbVe0AKAb4f97//Hy0EBTaiW8AalRnG/xAN5zOiWWyrNqNXeq8+KAuvRewjCVY1+IPxk4RdNYw==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1289,6 +1739,16 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1336,7 +1796,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -1836,7 +2295,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2177,7 +2635,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -2294,6 +2751,15 @@
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2702,6 +3168,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/esbuild": {
+      "version": "0.27.4",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
+      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.4",
+        "@esbuild/android-arm": "0.27.4",
+        "@esbuild/android-arm64": "0.27.4",
+        "@esbuild/android-x64": "0.27.4",
+        "@esbuild/darwin-arm64": "0.27.4",
+        "@esbuild/darwin-x64": "0.27.4",
+        "@esbuild/freebsd-arm64": "0.27.4",
+        "@esbuild/freebsd-x64": "0.27.4",
+        "@esbuild/linux-arm": "0.27.4",
+        "@esbuild/linux-arm64": "0.27.4",
+        "@esbuild/linux-ia32": "0.27.4",
+        "@esbuild/linux-loong64": "0.27.4",
+        "@esbuild/linux-mips64el": "0.27.4",
+        "@esbuild/linux-ppc64": "0.27.4",
+        "@esbuild/linux-riscv64": "0.27.4",
+        "@esbuild/linux-s390x": "0.27.4",
+        "@esbuild/linux-x64": "0.27.4",
+        "@esbuild/netbsd-arm64": "0.27.4",
+        "@esbuild/netbsd-x64": "0.27.4",
+        "@esbuild/openbsd-arm64": "0.27.4",
+        "@esbuild/openbsd-x64": "0.27.4",
+        "@esbuild/openharmony-arm64": "0.27.4",
+        "@esbuild/sunos-x64": "0.27.4",
+        "@esbuild/win32-arm64": "0.27.4",
+        "@esbuild/win32-ia32": "0.27.4",
+        "@esbuild/win32-x64": "0.27.4"
+      }
+    },
     "node_modules/escalade": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
@@ -2731,7 +3239,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2917,7 +3424,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3290,6 +3796,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -4725,6 +5246,19 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prism-react-renderer": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prism-react-renderer/-/prism-react-renderer-2.4.1.tgz",
+      "integrity": "sha512-ey8Ls/+Di31eqzUxC46h8MksNuGx/n0AAC8uKpwFau4RPDYLuE3EXTp8N8G2vX2N7UC/+IXeNUnlWBGGcAG+Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/prismjs": "^1.26.0",
+        "clsx": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.0.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -4773,7 +5307,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4783,7 +5316,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5451,7 +5983,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5516,6 +6047,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -5614,7 +6165,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5864,6 +6414,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
@@ -5890,7 +6462,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/slng-tts-next/package.json
+++ b/slng-tts-next/package.json
@@ -6,10 +6,12 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "proxy": "tsx scripts/ws-proxy.ts"
   },
   "dependencies": {
     "next": "16.1.2",
+    "prism-react-renderer": "^2.4.1",
     "react": "19.2.3",
     "react-dom": "19.2.3"
   },
@@ -17,8 +19,11 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/ws": "^8.18.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.2",
-    "typescript": "^5"
+    "tsx": "^4.21.0",
+    "typescript": "^5",
+    "ws": "^8.19.0"
   }
 }

--- a/slng-tts-next/scripts/ws-proxy.ts
+++ b/slng-tts-next/scripts/ws-proxy.ts
@@ -1,0 +1,110 @@
+import http from "node:http";
+import { WebSocketServer, WebSocket } from "ws";
+
+const PORT = Number(process.env.PORT) || 8787;
+
+const server = http.createServer();
+const wss = new WebSocketServer({ server });
+
+function closeSocket(socket: WebSocket, code: number, reason: string) {
+  if (socket.readyState === WebSocket.OPEN) {
+    socket.close(code, reason);
+  }
+}
+
+wss.on("connection", (client) => {
+  let upstream: WebSocket | null = null;
+  let upstreamReady = false;
+  let initialized = false;
+  const pending: Array<{ data: unknown; isBinary: boolean }> = [];
+
+  function flushPending() {
+    while (pending.length > 0 && upstreamReady && upstream) {
+      const { data, isBinary } = pending.shift()!;
+      upstream.send(data as Buffer, { binary: isBinary });
+    }
+  }
+
+  function connectUpstream(target: string, apiKey: string) {
+    upstream = new WebSocket(target, {
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+      },
+    });
+
+    upstream.on("open", () => {
+      upstreamReady = true;
+      flushPending();
+    });
+
+    upstream.on("message", (data: Buffer, isBinary: boolean) => {
+      if (client.readyState === WebSocket.OPEN) {
+        client.send(data, { binary: isBinary });
+      }
+    });
+
+    upstream.on("close", (code: number, reason: Buffer) => {
+      closeSocket(client, code, reason.toString());
+    });
+
+    upstream.on("error", () => {
+      closeSocket(client, 1011, "Upstream error");
+    });
+  }
+
+  client.on("message", (data: Buffer, isBinary: boolean) => {
+    if (!initialized) {
+      if (isBinary) {
+        closeSocket(client, 1008, "Expected JSON envelope");
+        return;
+      }
+
+      let envelope: { api_key?: string; apiKey?: string; target?: string; payload?: string } | null =
+        null;
+      try {
+        envelope = JSON.parse(data.toString());
+      } catch {
+        closeSocket(client, 1008, "Invalid JSON envelope");
+        return;
+      }
+
+      const apiKey = envelope?.api_key || envelope?.apiKey;
+      const target = envelope?.target;
+      if (!apiKey || !target) {
+        closeSocket(client, 1008, "Missing api_key or target");
+        return;
+      }
+
+      initialized = true;
+      connectUpstream(target, apiKey);
+
+      if (envelope?.payload) {
+        pending.push({ data: envelope.payload, isBinary: false });
+      }
+      return;
+    }
+
+    if (!upstream) {
+      pending.push({ data, isBinary });
+      return;
+    }
+
+    if (upstreamReady) {
+      upstream.send(data, { binary: isBinary });
+    } else {
+      pending.push({ data, isBinary });
+    }
+  });
+
+  client.on("close", () => {
+    if (upstream) upstream.close();
+  });
+
+  client.on("error", () => {
+    if (upstream) upstream.close();
+  });
+});
+
+server.listen(PORT, () => {
+  console.log(`WebSocket proxy listening on ws://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Add REST/WebSocket mode toggle with full WebSocket streaming, waveform visualization (Web Audio API + Canvas), and PCM gapless playback
- Expand model support: Deepgram Aura, ElevenLabs, Sarvam, Rime Arcana, Canopy Labs with dynamic voice dropdowns per provider
- Add session log console, status bar with connection states, syntax-highlighted code samples with copy button
- Add WebSocket proxy script (`scripts/ws-proxy.ts`) for local development
- Add advanced WS settings: proxy toggle, audio format, sample rate, custom payloads

## Test plan
- [ ] REST mode: enter API key, select model/voice, type text, click "Say it" — audio plays
- [ ] WebSocket mode: toggle to WS, start proxy (`npm run proxy`), enter API key, click "Connect" then "Say it" — waveform animates
- [ ] Switch models between providers — voice dropdown updates with correct voices
- [ ] Prompt chips set correct model + voice
- [ ] Code samples show syntax highlighting and copy button works
- [ ] Log console shows timestamped messages
- [ ] Mode switching disconnects WebSocket properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)