### PR TITLE
docs: remove ElevenLabs references (SLNG-795)

### DIFF
--- a/slng-tts-next/README.md
+++ b/slng-tts-next/README.md
@@ -55,7 +55,6 @@ The UI ships with presets for multiple providers:
 | Provider | Models |
 |----------|--------|
 | **Deepgram** | `deepgram/aura:2` |
-| **ElevenLabs** | `elevenlabs/eleven:3`, `eleven-flash:2`, `eleven-flash:2.5`, `eleven-multilingual:2` |
 | **Sarvam** | `sarvam/bulbul:v3` |
 | **SLNG / Deepgram** | `slng/deepgram/aura:2`, `aura:2-en`, `aura:2-es` |
 | **SLNG / Rime** | `slng/rime/arcana:3-en`, `:3-es`, `:3-fr`, `:3-hi`, `:ar`, `:de`, `:en`, `:es`, `:fr` |

--- a/slng-tts-next/app/lib/models.ts
+++ b/slng-tts-next/app/lib/models.ts
@@ -32,15 +32,6 @@ export const modelGroups: ModelGroup[] = [
     options: [{ value: "deepgram/aura:2", label: "deepgram/aura:2" }],
   },
   {
-    label: "ElevenLabs",
-    options: [
-      { value: "elevenlabs/eleven:3", label: "elevenlabs/eleven:3" },
-      { value: "elevenlabs/eleven-flash:2", label: "elevenlabs/eleven-flash:2" },
-      { value: "elevenlabs/eleven-flash:2.5", label: "elevenlabs/eleven-flash:2.5" },
-      { value: "elevenlabs/eleven-multilingual:2", label: "elevenlabs/eleven-multilingual:2" },
-    ],
-  },
-  {
     label: "Sarvam",
     options: [{ value: "sarvam/bulbul:v3", label: "sarvam/bulbul:v3" }],
   },
@@ -183,15 +174,6 @@ const rimeArcanaVoices: VoiceGroup[] = [
   },
 ];
 
-const elevenlabsVoices: VoiceGroup[] = [
-  {
-    label: "Default",
-    options: [
-      { value: "default", label: "Default voice" },
-    ],
-  },
-];
-
 const sarvamVoices: VoiceGroup[] = [
   {
     label: "Default",
@@ -229,12 +211,6 @@ export function getVoicesForModel(model: string): {
     return {
       groups: rimeArcanaVoices,
       docsUrl: "https://docs.slng.ai/voices/rime-arcana",
-    };
-  }
-  if (model.includes("elevenlabs")) {
-    return {
-      groups: elevenlabsVoices,
-      docsUrl: "https://docs.slng.ai/voices",
     };
   }
   if (model.includes("sarvam")) {


### PR DESCRIPTION
## Summary
- Remove ElevenLabs model group, voices config, and voice lookup from `slng-tts-next/app/lib/models.ts`
- Remove ElevenLabs row from the "Models Supported" table in `slng-tts-next/README.md`
- ElevenLabs references also removed from untracked HTML examples (`slng-aura-full-html`, `slng-aura-websocket-html`) — those files are not yet committed to the repo

Closes SLNG-795

## Test plan
- [x] `grep -ri elevenlabs` returns zero matches across tracked files
- [x] `npm run build` passes with no TypeScript errors
- [ ] Open app locally and confirm model dropdown no longer shows ElevenLabs options

🤖 Generated with [Claude Code](https://claude.com/claude-code)