### PR TITLE
feat(stt-next): support Sarvam Saaras v3 WebSocket protocol

### DIFF
--- a/slng-stt-next/app/hooks/useWebSocket.ts
+++ b/slng-stt-next/app/hooks/useWebSocket.ts
@@ -43,21 +43,32 @@ export function useWebSocket(callbacks: WsCallbacks) {
       setIsConnected(true);
 
       ws.addEventListener("open", () => {
-        callbacksRef.current.onLog("WebSocket open. Sending init.");
+        const hasInit = initMessage.trim().length > 0;
+        callbacksRef.current.onLog(
+          hasInit ? "WebSocket open. Sending init." : "WebSocket open. (no init message for this protocol)"
+        );
 
         if (useProxy) {
           const envelope = JSON.stringify({
             api_key: apiKey,
             target: wsUrl,
-            payload: initMessage,
+            payload: hasInit ? initMessage : undefined,
           });
           ws.send(envelope);
-          callbacksRef.current.onLog(`Sent proxy envelope with init`);
-        } else {
-          if (initMessage) {
-            ws.send(initMessage);
-            callbacksRef.current.onLog(`Sent init: ${initMessage}`);
-          }
+          callbacksRef.current.onLog(
+            hasInit ? `Sent proxy envelope with init` : `Sent proxy envelope (no init)`
+          );
+        } else if (hasInit) {
+          ws.send(initMessage);
+          callbacksRef.current.onLog(`Sent init: ${initMessage}`);
+        }
+
+        if (!hasInit) {
+          // Protocols that put config in the URL query string don't ack the
+          // session — mark ready as soon as the socket is open.
+          setIsReady(true);
+          callbacksRef.current.onStatusChange("Ready. Start speaking or send audio.");
+          return;
         }
 
         // Some providers send a ready/metadata message, others don't.
@@ -98,9 +109,10 @@ export function useWebSocket(callbacks: WsCallbacks) {
         callbacksRef.current.onBinaryMessage(event.data as ArrayBuffer);
       });
 
-      ws.addEventListener("close", () => {
-        callbacksRef.current.onLog("WebSocket closed.");
-        callbacksRef.current.onStatusChange("Disconnected.");
+      ws.addEventListener("close", (event) => {
+        const detail = `code=${event.code}${event.reason ? ` reason="${event.reason}"` : ""}${event.wasClean ? "" : " (not clean)"}`;
+        callbacksRef.current.onLog(`WebSocket closed. ${detail}`);
+        callbacksRef.current.onStatusChange(`Disconnected. ${detail}`, !event.wasClean);
         setIsReady(false);
         setIsConnected(false);
         socketRef.current = null;

--- a/slng-stt-next/app/lib/audio-utils.ts
+++ b/slng-stt-next/app/lib/audio-utils.ts
@@ -12,6 +12,21 @@ export function floatTo16BitPCM(float32Array: Float32Array): ArrayBuffer {
 }
 
 /**
+ * Base64-encode an ArrayBuffer. Chunks the conversion to avoid
+ * `String.fromCharCode(...)` call-stack overflow on long buffers.
+ */
+export function bufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, Math.min(i + chunkSize, bytes.length));
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+/**
  * Convert Int16 PCM bytes to Float32 samples (for Web Audio playback).
  */
 export function pcmToFloat32(pcmBytes: Uint8Array): Float32Array {

--- a/slng-stt-next/app/lib/models.ts
+++ b/slng-stt-next/app/lib/models.ts
@@ -64,7 +64,8 @@ export function getDefaultInitPayload(
   config: { sampleRate: number; language: string; encoding: string; enablePartials: boolean },
   protocol: WireProtocol
 ): string {
-  return JSON.stringify(protocol.buildInitMessage(config), null, 2);
+  const msg = protocol.buildInitMessage(config);
+  return msg === null ? "" : JSON.stringify(msg, null, 2);
 }
 
 export const languageOptions = [
@@ -80,3 +81,24 @@ export const languageOptions = [
   { value: "ar", label: "Arabic" },
   { value: "multi", label: "Multi-language (auto-detect)" },
 ];
+
+export const sarvamLanguageOptions = [
+  { value: "unknown", label: "Auto-detect" },
+  { value: "hi-IN", label: "Hindi (India)" },
+  { value: "en-IN", label: "English (India)" },
+  { value: "bn-IN", label: "Bengali (India)" },
+  { value: "gu-IN", label: "Gujarati (India)" },
+  { value: "kn-IN", label: "Kannada (India)" },
+  { value: "ml-IN", label: "Malayalam (India)" },
+  { value: "mr-IN", label: "Marathi (India)" },
+  { value: "od-IN", label: "Odia (India)" },
+  { value: "pa-IN", label: "Punjabi (India)" },
+  { value: "ta-IN", label: "Tamil (India)" },
+  { value: "te-IN", label: "Telugu (India)" },
+  { value: "ur-IN", label: "Urdu (India)" },
+];
+
+export function getLanguageOptions(model: string) {
+  if (model.startsWith("sarvam/")) return sarvamLanguageOptions;
+  return languageOptions;
+}

--- a/slng-stt-next/app/lib/protocols.ts
+++ b/slng-stt-next/app/lib/protocols.ts
@@ -1,3 +1,5 @@
+import { bufferToBase64 } from "./audio-utils";
+
 export type InitConfigInput = {
   sampleRate: number;
   language: string;
@@ -7,9 +9,15 @@ export type InitConfigInput = {
 
 export type WireProtocol = {
   // Identifier used by UI to pick code samples / docs.
-  name: "default" | "soniox-direct";
-  // Returns the full init message object (caller JSON-stringifies it).
-  buildInitMessage: (input: InitConfigInput) => Record<string, unknown>;
+  name: "default" | "soniox-direct" | "sarvam";
+  // Returns the init message object, or null to skip init entirely.
+  buildInitMessage: (input: InitConfigInput) => Record<string, unknown> | null;
+  // Optional: rewrite the WS URL (e.g. append query params).
+  buildUrl?: (baseUrl: string, input: InitConfigInput) => string;
+  // Optional: wrap a PCM16 chunk before sending. Default: raw binary.
+  wrapAudio?: (pcm: ArrayBuffer, input: InitConfigInput) => string | ArrayBuffer;
+  // Optional: mid-stream finalize signal. Default: {"type":"finalize"}.
+  finalizeText?: string;
   // Optional raw text frame sent before closing the socket.
   closeText?: string;
 };
@@ -42,6 +50,30 @@ const SONIOX_DIRECT_PROTOCOL: WireProtocol = {
   closeText: "",
 };
 
+const SARVAM_PROTOCOL: WireProtocol = {
+  name: "sarvam",
+  buildInitMessage: () => null,
+  buildUrl: (baseUrl, { sampleRate, language }) => {
+    const params = new URLSearchParams({
+      "language-code": language || "unknown",
+      mode: "transcribe",
+      sample_rate: String(sampleRate),
+      input_audio_codec: "linear16",
+      vad_signals: "true",
+    });
+    return `${baseUrl}?${params.toString()}`;
+  },
+  wrapAudio: (pcm, { sampleRate }) =>
+    JSON.stringify({
+      audio: {
+        data: bufferToBase64(pcm),
+        sample_rate: sampleRate,
+        encoding: "linear16",
+      },
+    }),
+  finalizeText: JSON.stringify({ type: "flush" }),
+};
+
 type ProtocolOverride = {
   modelPrefix: string;
   directOnly?: boolean;
@@ -53,6 +85,11 @@ const PROTOCOL_OVERRIDES: ProtocolOverride[] = [
     modelPrefix: "soniox/",
     directOnly: true,
     protocol: SONIOX_DIRECT_PROTOCOL,
+  },
+  {
+    modelPrefix: "sarvam/",
+    directOnly: true,
+    protocol: SARVAM_PROTOCOL,
   },
 ];
 

--- a/slng-stt-next/app/page.tsx
+++ b/slng-stt-next/app/page.tsx
@@ -13,6 +13,7 @@ import { useMicrophone } from "./hooks/useMicrophone";
 import {
   modelGroups,
   languageOptions,
+  getLanguageOptions,
   getWsUrl,
   getDefaultInitPayload,
   BRIDGES_BASE_URL,
@@ -106,6 +107,9 @@ export default function Home() {
     // Try various response formats
     if (typeof payload.transcript === "string") return payload.transcript;
     if (typeof payload.text === "string") return payload.text;
+    // Sarvam: { type: "data", data: { transcript: "…" } }
+    const data = payload.data as Record<string, unknown> | undefined;
+    if (data && typeof data.transcript === "string") return data.transcript;
     // Deepgram nested format
     const channel = payload.channel as Record<string, unknown> | undefined;
     if (channel?.alternatives) {
@@ -131,6 +135,8 @@ export default function Home() {
     if (payload.speech_final === true) return true;
     const type = (payload.type as string)?.toLowerCase();
     if (type === "final_transcript") return true;
+    // Sarvam emits final transcripts only, under type "data"
+    if (type === "data") return true;
     // Soniox: every token in the array is final
     const tokens = payload.tokens as Array<Record<string, unknown>> | undefined;
     if (Array.isArray(tokens) && tokens.length > 0) {
@@ -145,6 +151,24 @@ export default function Home() {
       // Skip metadata/ready messages — not transcript data
       const msgType = (payload.type as string)?.toLowerCase();
       if (msgType === "metadata" || msgType === "ready") return;
+
+      // Sarvam: VAD events — just log them
+      if (msgType === "events") {
+        const data = payload.data as Record<string, unknown> | undefined;
+        const signal = typeof data?.signal_type === "string" ? data.signal_type : "?";
+        appendLog(`VAD: ${signal}`);
+        return;
+      }
+
+      // Sarvam / gateway error frames
+      if (msgType === "error") {
+        const data = payload.data as Record<string, unknown> | undefined;
+        const message = typeof data?.message === "string" ? data.message : "Unknown error";
+        const code = typeof data?.code === "string" ? ` (${data.code})` : "";
+        setStatusMessage(`Server error: ${message}${code}`, true);
+        appendLog(`Server error: ${message}${code}`);
+        return;
+      }
 
       // Soniox tokens[]: per-token final/partial split
       const tokens = payload.tokens as Array<Record<string, unknown>> | undefined;
@@ -209,12 +233,26 @@ export default function Home() {
     onStatusChange: setStatusMessage,
   });
 
-  // -- Audio sender (raw binary frames; kept as a helper for future protocol variants) --
+  // -- Audio sender. Some protocols (Sarvam) need each PCM chunk wrapped as JSON. --
   const sendAudio = useCallback(
     (pcmData: ArrayBuffer) => {
+      if (protocol.wrapAudio) {
+        const frame = protocol.wrapAudio(pcmData, {
+          sampleRate: parsedSampleRate,
+          language,
+          encoding,
+          enablePartials,
+        });
+        if (typeof frame === "string") {
+          sendJson(frame);
+        } else {
+          sendBinary(frame);
+        }
+        return;
+      }
       sendBinary(pcmData);
     },
-    [sendBinary]
+    [protocol, parsedSampleRate, language, encoding, enablePartials, sendBinary, sendJson]
   );
 
   // -- Microphone --
@@ -243,6 +281,11 @@ export default function Home() {
 
   // -- Auto-select language from model suffix --
   useEffect(() => {
+    // Sarvam uses BCP-47 codes; default to auto-detect when this model is picked.
+    if (model.startsWith("sarvam/")) {
+      setLanguage("unknown");
+      return;
+    }
     const match = model.match(/:[\w]+-(\w+)$/);
     if (match) {
       const suffix = match[1];
@@ -250,6 +293,14 @@ export default function Home() {
       if (lang) setLanguage(suffix);
     }
   }, [model]);
+
+  // -- Sarvam only exposes a direct-WS endpoint (no bridge channel). --
+  useEffect(() => {
+    if (model.startsWith("sarvam/") && !useDirectUrl) setUseDirectUrl(true);
+  }, [model, useDirectUrl]);
+
+  const isSarvam = model.startsWith("sarvam/");
+  const currentLanguageOptions = useMemo(() => getLanguageOptions(model), [model]);
 
   // -- Update custom init when config changes --
   useEffect(() => {
@@ -310,20 +361,28 @@ export default function Home() {
       return;
     }
 
-    const initObject = protocol.buildInitMessage({
+    const configInput = {
       sampleRate: parsedSampleRate,
       language,
       encoding,
       enablePartials,
-    });
+    };
+
+    const initObject = protocol.buildInitMessage(configInput);
 
     const initMessage = useCustomInit
       ? customInitPayload.trim()
-      : JSON.stringify(initObject);
+      : initObject === null
+        ? ""
+        : JSON.stringify(initObject);
+
+    const finalWsUrl = protocol.buildUrl
+      ? protocol.buildUrl(wsUrl.trim(), configInput)
+      : wsUrl.trim();
 
     const doConnect = () => {
       connect({
-        wsUrl: wsUrl.trim(),
+        wsUrl: finalWsUrl,
         apiKey: apiKey.trim(),
         useProxy,
         proxyUrl: proxyUrl.trim(),
@@ -372,7 +431,7 @@ export default function Home() {
     if (isRecording) {
       stopRecording();
       // Send finalize to tell the server we're done
-      sendJson(JSON.stringify({ type: "finalize" }));
+      sendJson(protocol.finalizeText ?? JSON.stringify({ type: "finalize" }));
       setStatusMessage("Recording stopped. Waiting for final transcript...");
       appendLog("Sent finalize signal.");
     } else {
@@ -391,6 +450,7 @@ export default function Home() {
     parsedSampleRate,
     setStatusMessage,
     appendLog,
+    protocol,
   ]);
 
   // -- Send file audio over WebSocket --
@@ -430,7 +490,7 @@ export default function Home() {
         await new Promise((r) => setTimeout(r, 500));
       }
 
-      sendJson(JSON.stringify({ type: "finalize" }));
+      sendJson(protocol.finalizeText ?? JSON.stringify({ type: "finalize" }));
       appendLog("File streaming complete. Sent finalize.");
       setStatusMessage("File sent. Waiting for transcript...");
     } catch (err) {
@@ -441,7 +501,7 @@ export default function Home() {
       fileStreamingRef.current = false;
       setIsStreamingPlayback(false);
     }
-  }, [selectedFile, isReady, parsedSampleRate, sendAudio, sendJson, setStatusMessage, appendLog, ensureAudioContext, resetPlayTime, playPcmChunk]);
+  }, [selectedFile, isReady, parsedSampleRate, sendAudio, sendJson, setStatusMessage, appendLog, ensureAudioContext, resetPlayTime, playPcmChunk, protocol]);
 
   // -- Send URL audio over WebSocket --
   const handleSendUrl = useCallback(async () => {
@@ -487,7 +547,7 @@ export default function Home() {
         await new Promise((r) => setTimeout(r, 500));
       }
 
-      sendJson(JSON.stringify({ type: "finalize" }));
+      sendJson(protocol.finalizeText ?? JSON.stringify({ type: "finalize" }));
       appendLog("URL audio streaming complete. Sent finalize.");
       setStatusMessage("Audio sent. Waiting for transcript...");
     } catch (err) {
@@ -497,7 +557,7 @@ export default function Home() {
       setIsBusy(false);
       setIsStreamingPlayback(false);
     }
-  }, [audioUrl, isReady, parsedSampleRate, sendAudio, sendJson, setStatusMessage, appendLog, ensureAudioContext, resetPlayTime, playPcmChunk]);
+  }, [audioUrl, isReady, parsedSampleRate, sendAudio, sendJson, setStatusMessage, appendLog, ensureAudioContext, resetPlayTime, playPcmChunk, protocol]);
 
   // -- HTTP file upload --
   const handleHttpTranscribe = useCallback(async () => {
@@ -765,7 +825,7 @@ export default function Home() {
               value={language}
               onChange={(e) => setLanguage(e.target.value)}
             >
-              {languageOptions.map((opt) => (
+              {currentLanguageOptions.map((opt) => (
                 <option key={opt.value} value={opt.value}>
                   {opt.label}
                 </option>
@@ -1029,6 +1089,68 @@ function endStream(ws) {
 }`}
               />
             )}
+            {isWs && protocol.name === "sarvam" && (
+              <CodeBlock
+                title="WebSocket — Streaming STT (Sarvam Saaras v3)"
+                language="javascript"
+                wide
+                code={`const MODEL = "${model}";
+const SAMPLE_RATE = ${parsedSampleRate};
+const LANGUAGE = "${language}"; // BCP-47 (e.g. "hi-IN") or "unknown" for auto-detect
+
+// 1. Session config goes in the URL query string — no init message.
+const url = new URL("${wsUrl}");
+url.searchParams.set("language-code", LANGUAGE);
+url.searchParams.set("mode", "transcribe");
+url.searchParams.set("sample_rate", String(SAMPLE_RATE));
+url.searchParams.set("input_audio_codec", "linear16");
+url.searchParams.set("vad_signals", "true");
+
+const ws = new WebSocket(url);
+
+ws.onmessage = (event) => {
+  const msg = JSON.parse(event.data);
+  if (msg.type === "data")   console.log("Transcript:", msg.data.transcript);
+  if (msg.type === "events") console.log("VAD:", msg.data.signal_type);
+  if (msg.type === "error")  console.error("Error:", msg.data.message);
+};
+
+// 2. Audio frames are base64-encoded JSON — not raw binary.
+async function startMicrophone(ws, sampleRate) {
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: { sampleRate, channelCount: 1 },
+  });
+  const ctx = new AudioContext({ sampleRate });
+  await ctx.audioWorklet.addModule("/audio-processor.js");
+  const source = ctx.createMediaStreamSource(stream);
+  const worklet = new AudioWorkletNode(ctx, "pcm-processor");
+
+  worklet.port.onmessage = (e) => {
+    const float32 = e.data;
+    const pcm16 = new ArrayBuffer(float32.length * 2);
+    const view = new DataView(pcm16);
+    for (let i = 0; i < float32.length; i++) {
+      const s = Math.max(-1, Math.min(1, float32[i]));
+      view.setInt16(i * 2, s < 0 ? s * 0x8000 : s * 0x7FFF, true);
+    }
+    const bytes = new Uint8Array(pcm16);
+    let bin = "";
+    for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+    ws.send(JSON.stringify({
+      audio: { data: btoa(bin), sample_rate: sampleRate, encoding: "linear16" },
+    }));
+  };
+
+  source.connect(worklet);
+  worklet.connect(ctx.destination);
+}
+
+// 3. Mid-stream finalize: ask the server to flush the current utterance.
+function flush(ws) {
+  ws.send(JSON.stringify({ type: "flush" }));
+}`}
+              />
+            )}
           </div>
         </details>
 
@@ -1052,6 +1174,8 @@ function endStream(ws) {
                   id="urlPattern"
                   value={useDirectUrl ? "direct" : "bridge"}
                   onChange={(e) => setUseDirectUrl(e.target.value === "direct")}
+                  disabled={isSarvam}
+                  title={isSarvam ? "Sarvam Saaras v3 only has a direct WebSocket channel." : undefined}
                 >
                   <option value="bridge">Bridge (/v1/bridges/unmute/stt/)</option>
                   <option value="direct">Direct (/v1/stt/)</option>

--- a/slng-stt-next/scripts/ws-proxy.ts
+++ b/slng-stt-next/scripts/ws-proxy.ts
@@ -6,9 +6,18 @@ const PORT = Number(process.env.PORT) || 8787;
 const server = http.createServer();
 const wss = new WebSocketServer({ server });
 
+function isValidCloseCode(code: number): boolean {
+  // WebSocket spec: 1000, 1001, 1002, 1003, 1007-1011, 1012-1014, 3000-4999.
+  if (code === 1000 || code === 1001 || code === 1002 || code === 1003) return true;
+  if (code >= 1007 && code <= 1014) return true;
+  if (code >= 3000 && code <= 4999) return true;
+  return false;
+}
+
 function closeSocket(socket: WebSocket, code: number, reason: string) {
-  if (socket.readyState === WebSocket.OPEN) {
-    socket.close(code, reason);
+  if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+    const safeCode = isValidCloseCode(code) ? code : 1011;
+    socket.close(safeCode, reason.slice(0, 120));
   }
 }
 
@@ -26,6 +35,7 @@ wss.on("connection", (client) => {
   }
 
   function connectUpstream(target: string, apiKey: string) {
+    console.log(`[proxy] upstream connect → ${target}`);
     upstream = new WebSocket(target, {
       headers: {
         Authorization: `Bearer ${apiKey}`,
@@ -33,8 +43,20 @@ wss.on("connection", (client) => {
     });
 
     upstream.on("open", () => {
+      console.log(`[proxy] upstream open ← ${target}`);
       upstreamReady = true;
       flushPending();
+    });
+
+    upstream.on("unexpected-response", (_req, res) => {
+      console.log(`[proxy] upstream unexpected-response status=${res.statusCode}`);
+      let body = "";
+      res.on("data", (c: Buffer) => (body += c.toString()));
+      res.on("end", () => {
+        const detail = body.slice(0, 200);
+        console.log(`[proxy] upstream body: ${detail}`);
+        closeSocket(client, 1011, `Upstream HTTP ${res.statusCode}: ${detail}`);
+      });
     });
 
     upstream.on("message", (data: Buffer, isBinary: boolean) => {
@@ -44,11 +66,14 @@ wss.on("connection", (client) => {
     });
 
     upstream.on("close", (code: number, reason: Buffer) => {
-      closeSocket(client, code, reason.toString());
+      const reasonText = reason.toString();
+      console.log(`[proxy] upstream close code=${code} reason="${reasonText}"`);
+      closeSocket(client, code, reasonText || `Upstream closed (${code})`);
     });
 
-    upstream.on("error", () => {
-      closeSocket(client, 1011, "Upstream error");
+    upstream.on("error", (err: Error) => {
+      console.log(`[proxy] upstream error: ${err.message}`);
+      closeSocket(client, 1011, `Upstream error: ${err.message}`);
     });
   }
 


### PR DESCRIPTION
## Summary

- Add a Sarvam-specific protocol to the STT Next.js demo so `sarvam/saaras:v3` actually connects instead of disconnecting immediately.
- Sarvam's `/v1/stt/sarvam/saaras:v3` channel ([gateway-specs#178](https://github.com/slng-ai/gateway-specs/pull/178)) is meaningfully different from the unified-bridge schema the demo was sending: session config goes in the URL **query string** (no init JSON), audio frames are **base64-encoded JSON** (not raw binary), the mid-stream finalize signal is `{"type":"flush"}`, and the server emits typed `data` / `events` / `error` messages.

## What changed

- `app/lib/protocols.ts` — extended `WireProtocol` with optional `buildUrl`, `wrapAudio`, `finalizeText` hooks. Added `SARVAM_PROTOCOL` and registered it via `PROTOCOL_OVERRIDES` (direct-only). Default and Soniox protocols are unchanged.
- `app/lib/audio-utils.ts` — small `bufferToBase64` helper (chunked, no call-stack overflow on long buffers).
- `app/lib/models.ts` — `sarvamLanguageOptions` (BCP-47 + `unknown`) and `getLanguageOptions(model)`. `getDefaultInitPayload` returns `""` when the protocol skips init.
- `app/hooks/useWebSocket.ts` — when `initMessage` is empty, skip the init send and mark Ready immediately. Close handler logs `code=… reason="…" (not clean)` so disconnects are debuggable.
- `app/page.tsx` — wired `buildUrl` / `wrapAudio` into `handleConnect` / `sendAudio`. Mid-stream finalize uses `protocol.finalizeText ?? {"type":"finalize"}`. Sarvam VAD events log to the session console; `error` frames surface in the status bar. Language dropdown swaps to BCP-47 when Sarvam is selected, language defaults to `unknown`, URL-pattern is forced to Direct. Added a Sarvam-specific "How to implement" code sample.
- `scripts/ws-proxy.ts` — surfaces upstream HTTP upgrade errors (status + body) and upstream WS close code/reason both to the proxy terminal and back to the browser, instead of swallowing them.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `next build` succeeds
- [x] Connect with `sarvam/saaras:v3`, `language=hi-IN`, speak Hindi — Ready, transcripts arrive on `type:"data"` frames, VAD signals log to the session console
- [ ] Force a bad language code — `type:"error"` frame surfaces in the status bar
- [ ] Regression: `slng/deepgram/nova:3-en` (default protocol) still connects in both Bridge and Direct mode, microphone + file flows work
- [ ] Regression: `soniox/speech-ai:rt-v3` direct mode still works