### PR TITLE
Adapt TTS & STT demos to the SLNG design system

### DIFF
--- a/slng-stt-next/app/components/CodeBlock.tsx
+++ b/slng-stt-next/app/components/CodeBlock.tsx
@@ -20,12 +20,20 @@ export function CodeBlock({ code, language, title, wide }: CodeBlockProps) {
   };
 
   return (
-    <div className={`code-card ${wide ? "wide" : ""}`}>
-      <div className="code-card-header">
-        {title && <h3>{title}</h3>}
+    <div
+      className={`overflow-hidden rounded-md border border-border bg-secondary p-3 ${
+        wide ? "md:col-span-2" : ""
+      }`}
+    >
+      <div className="mb-2 flex items-center justify-between">
+        {title && (
+          <h3 className="m-0 font-mono text-xs uppercase tracking-wider text-muted-foreground">
+            {title}
+          </h3>
+        )}
         <button
           type="button"
-          className="copy-btn"
+          className="rounded-full border border-border bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
           onClick={handleCopy}
         >
           {copied ? "Copied!" : "Copy"}
@@ -33,7 +41,10 @@ export function CodeBlock({ code, language, title, wide }: CodeBlockProps) {
       </div>
       <Highlight theme={themes.nightOwl} code={code.trim()} language={language}>
         {({ style, tokens, getLineProps, getTokenProps }) => (
-          <pre style={{ ...style, margin: 0, padding: "12px", borderRadius: "var(--radius)", fontSize: "0.75rem", lineHeight: 1.5, overflowX: "auto" }}>
+          <pre
+            className="m-0 overflow-x-auto rounded-md p-3 font-mono text-xs leading-relaxed"
+            style={style}
+          >
             {tokens.map((line, i) => (
               <div key={i} {...getLineProps({ line })}>
                 {line.map((token, key) => (

--- a/slng-stt-next/app/components/LogConsole.tsx
+++ b/slng-stt-next/app/components/LogConsole.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { ChevronRight, Trash2 } from "lucide-react";
+import { cn } from "./ui/lib/utils";
 import type { LogEntry } from "../hooks/useSessionLog";
 
 type LogConsoleProps = {
@@ -12,45 +14,38 @@ export function LogConsole({ entries, onClear }: LogConsoleProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="log-section">
-      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+    <div className="mt-3">
+      <div className="flex items-center gap-2">
         <button
-          className={`log-toggle ${isOpen ? "open" : ""}`}
           type="button"
+          className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
           onClick={() => setIsOpen((prev) => !prev)}
         >
-          <span className="arrow">&#9654;</span> Log
+          <ChevronRight
+            className={cn("h-3.5 w-3.5 transition-transform", isOpen && "rotate-90")}
+          />
+          Log
         </button>
         {isOpen && entries.length > 0 && onClear && (
           <button
             type="button"
             onClick={onClear}
             title="Clear logs"
-            style={{
-              background: "transparent",
-              border: "none",
-              cursor: "pointer",
-              padding: 2,
-              lineHeight: 1,
-            }}
+            className="text-muted-foreground transition-colors hover:text-foreground"
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--foreground, #333)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="3 6 5 6 21 6" />
-              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-              <path d="M10 11v6" />
-              <path d="M14 11v6" />
-              <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-            </svg>
+            <Trash2 className="h-3.5 w-3.5" />
           </button>
         )}
       </div>
-      <div className={`log ${isOpen ? "open" : ""}`}>
-        {entries.map((entry, i) => (
-          <div key={i}>
-            {entry.timestamp} {entry.message}
-          </div>
-        ))}
-      </div>
+      {isOpen && (
+        <div className="mt-1.5 max-h-40 overflow-y-auto whitespace-pre-wrap break-all rounded-md border border-border bg-secondary p-3 font-mono text-xs text-muted-foreground">
+          {entries.map((entry, i) => (
+            <div key={i}>
+              {entry.timestamp} {entry.message}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/slng-stt-next/app/components/StatusBar.tsx
+++ b/slng-stt-next/app/components/StatusBar.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { cn } from "./ui/lib/utils";
+
 type StatusBarProps = {
   status: string;
   isError: boolean;
@@ -13,18 +15,27 @@ export function StatusBar({
   isConnected,
   isReady,
 }: StatusBarProps) {
-  let barClass = "status-bar";
-  if (isError) {
-    barClass += " error";
-  } else if (isReady) {
-    barClass += " ready";
-  } else if (isConnected) {
-    barClass += " connected";
-  }
-
   return (
-    <div className={barClass}>
-      <span className="status-dot" />
+    <div
+      className={cn(
+        "mt-4 flex items-center gap-2 rounded-md px-3 py-2 text-sm",
+        isError
+          ? "bg-destructive/10 text-destructive"
+          : "bg-secondary text-muted-foreground"
+      )}
+    >
+      <span
+        className={cn(
+          "h-2 w-2 shrink-0 rounded-full",
+          isError
+            ? "bg-destructive"
+            : isReady
+              ? "bg-brand-yellow animate-slng-pulse"
+              : isConnected
+                ? "bg-brand-yellow"
+                : "bg-border"
+        )}
+      />
       <span>{status}</span>
     </div>
   );

--- a/slng-stt-next/app/components/TranscriptDisplay.tsx
+++ b/slng-stt-next/app/components/TranscriptDisplay.tsx
@@ -23,26 +23,36 @@ export function TranscriptDisplay({
   };
 
   return (
-    <div className="transcript-wrap">
-      <div className="transcript-label">Transcript</div>
+    <div className="mt-4 max-h-[400px] min-h-[120px] overflow-y-auto rounded-lg border border-border bg-secondary p-4">
+      <div className="mb-2 font-mono text-xs uppercase tracking-wider text-muted-foreground">
+        Transcript
+      </div>
       {!finalText && !partialText ? (
-        <div className="transcript-empty">
+        <div className="text-sm italic text-muted-foreground">
           Waiting for audio...
         </div>
       ) : (
-        <>
-          {finalText && <span className="transcript-final">{finalText}</span>}
+        <p className="m-0 text-base leading-relaxed">
+          {finalText && <span className="text-foreground">{finalText}</span>}
           {partialText && (
-            <span className="transcript-partial"> {partialText}</span>
+            <span className="italic text-muted-foreground"> {partialText}</span>
           )}
-        </>
+        </p>
       )}
       {fullText && (
-        <div className="transcript-actions">
-          <button type="button" onClick={handleCopy}>
+        <div className="mt-3 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={handleCopy}
+            className="rounded-full border border-border bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
             {copied ? "Copied!" : "Copy"}
           </button>
-          <button type="button" onClick={onClear}>
+          <button
+            type="button"
+            onClick={onClear}
+            className="rounded-full border border-border bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+          >
             Clear
           </button>
         </div>

--- a/slng-stt-next/app/components/WaveformCanvas.tsx
+++ b/slng-stt-next/app/components/WaveformCanvas.tsx
@@ -29,9 +29,9 @@ export function WaveformCanvas({
       resizeCanvas();
       const ctx = canvas!.getContext("2d");
       if (!ctx) return;
+      const dpr = window.devicePixelRatio || 1;
       const w = canvas!.width;
       const h = canvas!.height;
-      const dpr = window.devicePixelRatio || 1;
 
       ctx.clearRect(0, 0, w, h);
       ctx.lineWidth = 2 * dpr;
@@ -98,8 +98,8 @@ export function WaveformCanvas({
   }, [analyserNode, isActive]);
 
   return (
-    <div className="waveform-wrap">
-      <canvas ref={canvasRef} />
+    <div className="mt-4 overflow-hidden rounded-lg border border-border bg-secondary">
+      <canvas ref={canvasRef} className="block h-20 w-full" />
     </div>
   );
 }

--- a/slng-stt-next/app/components/ui/badge.tsx
+++ b/slng-stt-next/app/components/ui/badge.tsx
@@ -1,0 +1,39 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cn } from './lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border border-transparent px-2.5 py-0.5 text-xs font-normal font-mono tracking-[-0.072px] leading-4 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow',
+        secondary: 'bg-secondary text-secondary-foreground',
+        success: 'bg-emerald-500/10 text-emerald-600 ring-1 ring-inset ring-emerald-500/30',
+        warning: 'bg-amber-500/10 text-amber-600 ring-1 ring-inset ring-amber-500/30',
+        destructive: 'bg-destructive text-destructive-foreground',
+        outline: 'text-foreground',
+        // Outlined status variants with colored borders (matching Figma design - no background)
+        'status-active': 'bg-transparent text-emerald-700 border-emerald-700',
+        'status-pending': 'bg-transparent text-amber-600 border-amber-600',
+        'status-expired': 'bg-transparent text-red-600 border-red-600',
+        'status-revoked': 'bg-transparent text-muted-foreground border-muted-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(({ className, variant, ...props }, ref) => (
+  <div ref={ref} className={cn(badgeVariants({ variant }), className)} {...props} />
+));
+Badge.displayName = 'Badge';
+
+export { Badge, badgeVariants };

--- a/slng-stt-next/app/components/ui/button.tsx
+++ b/slng-stt-next/app/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from './lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp className={cn(buttonVariants({ variant, size }), className)} ref={ref} {...props} />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/slng-stt-next/app/components/ui/card.tsx
+++ b/slng-stt-next/app/components/ui/card.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+import { cn } from './lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-xl border border-border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  )
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/slng-stt-next/app/components/ui/input.tsx
+++ b/slng-stt-next/app/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from './lib/utils';
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type = 'text', ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/slng-stt-next/app/components/ui/label.tsx
+++ b/slng-stt-next/app/components/ui/label.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+
+import { cn } from './lib/utils';
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/slng-stt-next/app/components/ui/lib/utils.ts
+++ b/slng-stt-next/app/components/ui/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/slng-stt-next/app/components/ui/tabs.tsx
+++ b/slng-stt-next/app/components/ui/tabs.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from './lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn('inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground', className)}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=inactive]:opacity-50',
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn('mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2', className)}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/slng-stt-next/app/components/ui/textarea.tsx
+++ b/slng-stt-next/app/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from './lib/utils';
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        className={cn(
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/slng-stt-next/app/globals.css
+++ b/slng-stt-next/app/globals.css
@@ -1,793 +1,141 @@
+@import "tailwindcss";
+
+/* Class-based dark mode (matches the SLNG product design system). */
+@custom-variant dark (&:is(.dark *));
+
+/* ── Design tokens (Figma-exact, from slng-ai/frontend) ── */
 :root {
-  color-scheme: light;
   --background: #fbfaf7;
   --foreground: #15120d;
-  --card: #ffffff;
+
+  --card: #fffffd;
   --card-foreground: #15120d;
+
   --popover: #ffffff;
   --popover-foreground: #15120d;
+
   --primary: #15120d;
   --primary-foreground: #ffffff;
+
   --secondary: #f3f2ed;
   --secondary-foreground: #15120d;
+
   --muted: #f3f2ed;
-  --muted-foreground: #8a8983;
-  --accent: #fbe566;
+  --muted-foreground: #5e5e59;
+
+  --accent: #f3f2ed;
   --accent-foreground: #15120d;
-  --destructive: #ef4444;
+
+  --destructive: 0 84% 60%;
   --destructive-foreground: #ffffff;
-  --border: #cac9c4;
-  --input: #cac9c4;
-  --ring: #fbe566;
-  --radius: 0.5rem;
-  --font-body: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-  --shadow-soft: 0 24px 50px rgba(21, 18, 13, 0.12);
-}
-
-:root[data-theme="dark"] {
-  color-scheme: dark;
-  --background: #1a1a1a;
-  --foreground: #f3f2ed;
-  --card: #1f1f1f;
-  --card-foreground: #f3f2ed;
-  --popover: #1f1f1f;
-  --popover-foreground: #f3f2ed;
-  --primary: #fbe566;
-  --primary-foreground: #15120d;
-  --secondary: #2b2a25;
-  --secondary-foreground: #f3f2ed;
-  --muted: #23221e;
-  --muted-foreground: #cac9c4;
-  --accent: #43a1e1;
-  --accent-foreground: #ffffff;
-  --border: #2c2b26;
-  --input: #2c2b26;
-  --ring: #fbe566;
-}
-
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-}
-
-html {
-  scroll-behavior: smooth;
-}
-
-body {
-  min-height: 100vh;
-  background: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-body);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  background-image: radial-gradient(
-      circle at 20% 10%,
-      color-mix(in srgb, var(--accent) 40%, transparent),
-      transparent 65%
-    ),
-    radial-gradient(
-      circle at 80% 0%,
-      color-mix(in srgb, var(--secondary) 60%, transparent),
-      transparent 55%
-    );
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-button,
-input,
-select,
-textarea {
-  font: inherit;
-}
-
-.page {
-  max-width: 920px;
-  margin: 0 auto;
-  padding: 36px 18px 28px;
-  display: grid;
-  gap: 20px;
-}
-
-.page-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.logo {
-  width: 46px;
-  height: 46px;
-  border-radius: 16px;
-  display: grid;
-  place-items: center;
-  background: var(--accent);
-  color: var(--accent-foreground);
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--foreground) 20%, transparent);
-}
-
-.logo img {
-  width: 28px;
-  height: 28px;
-  display: block;
-}
-
-.brand-title {
-  font-size: 1.35rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  margin: 0;
-}
-
-.brand-subtitle {
-  display: block;
-  font-size: 0.85rem;
-  color: var(--muted-foreground);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.card {
-  background: var(--card);
-  color: var(--card-foreground);
-  border: 1px solid var(--border);
-  border-radius: calc(var(--radius) * 2);
-  padding: 24px;
-  box-shadow: var(--shadow-soft);
-}
-
-.card.is-recording {
-  border-color: color-mix(in srgb, var(--accent) 65%, var(--border));
-  box-shadow: 0 28px 60px rgba(21, 18, 13, 0.18);
-}
-
-h1 {
-  font-size: 2rem;
-  margin: 0 0 12px;
-}
-
-p {
-  margin: 0 0 16px;
-  color: var(--muted-foreground);
-}
-
-label {
-  font-weight: 600;
-  display: block;
-  margin: 12px 0 8px;
-}
-
-textarea,
-input[type="password"],
-input[type="text"],
-input[type="url"],
-input[type="file"],
-select {
-  width: 100%;
-  padding: 12px;
-  border-radius: var(--radius);
-  border: 1px solid var(--input);
-  font-size: 0.98rem;
-  background: var(--popover);
-  color: var(--popover-foreground);
-}
-
-textarea {
-  min-height: 120px;
-  resize: vertical;
-}
-
-.row {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-top: 16px;
-}
-
-.row > * {
-  flex: 1 1 240px;
-}
-
-button {
-  background: var(--primary);
-  color: var(--primary-foreground);
-  border: none;
-  padding: 12px 18px;
-  border-radius: 999px;
-  font-weight: 600;
-  cursor: pointer;
-  box-shadow: 0 10px 20px rgba(21, 18, 13, 0.2);
-}
-
-button:disabled {
-  cursor: not-allowed;
-}
-
-.hero-button:disabled {
-  opacity: 1;
-  background: var(--muted);
-  color: var(--muted-foreground);
-  box-shadow: none;
-}
-
-.hero-button {
-  font-size: 1rem;
-  letter-spacing: 0.02em;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: 48px;
-}
-
-.hero-button .pulse {
-  display: inline-flex;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--accent);
-  box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 60%, transparent);
-  animation: pulse 1.8s ease-out infinite;
-}
-
-.hero-button.is-loading .pulse {
-  animation: pulse 0.8s ease-in-out infinite;
-}
-
-.hero-button.is-disabled .pulse {
-  animation: none;
-  box-shadow: none;
-  opacity: 0;
-}
-
-.hero-button.is-recording {
-  background: var(--destructive);
-  color: var(--destructive-foreground);
-}
-
-.hero-button.is-recording .pulse {
-  background: var(--destructive-foreground);
-}
-
-button:focus-visible,
-input:focus-visible,
-textarea:focus-visible,
-select:focus-visible {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
-}
-
-.cta-link {
-  display: inline-block;
-  margin-top: 10px;
-  color: var(--foreground);
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.cta-link:hover {
-  text-decoration: underline;
-}
-
-/* -- Mode toggle -- */
-.mode-toggle {
-  display: inline-flex;
-  background: var(--secondary);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 3px;
-  gap: 2px;
-  margin-bottom: 20px;
-}
-
-.mode-toggle button {
-  padding: 7px 16px;
-  border-radius: 999px;
-  font-size: 0.82rem;
-  font-weight: 600;
-  border: none;
-  cursor: pointer;
-  background: transparent;
-  color: var(--muted-foreground);
-  box-shadow: none;
-  transition: all 0.15s;
-  letter-spacing: 0.01em;
-}
-
-.mode-toggle button.active {
-  background: var(--card);
-  color: var(--foreground);
-  box-shadow: 0 1px 3px rgba(21, 18, 13, 0.1);
-}
-
-/* -- Input source toggle -- */
-.input-source-toggle {
-  display: inline-flex;
-  background: var(--secondary);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 3px;
-  gap: 2px;
-  margin-bottom: 16px;
-}
-
-.input-source-toggle button {
-  padding: 7px 16px;
-  border-radius: 999px;
-  font-size: 0.82rem;
-  font-weight: 600;
-  border: none;
-  cursor: pointer;
-  background: transparent;
-  color: var(--muted-foreground);
-  box-shadow: none;
-  transition: all 0.15s;
-  letter-spacing: 0.01em;
-}
-
-.input-source-toggle button.active {
-  background: var(--card);
-  color: var(--foreground);
-  box-shadow: 0 1px 3px rgba(21, 18, 13, 0.1);
-}
-
-/* -- Model row -- */
-.model-row {
-  display: flex;
-  gap: 12px;
-  align-items: flex-end;
-  flex-wrap: wrap;
-  margin-top: 16px;
-}
-
-.model-row .field {
-  flex: 1 1 280px;
-}
-
-.model-link {
-  font-size: 0.8rem;
-  font-weight: 400;
-  color: var(--foreground);
-  text-decoration: none;
-  margin-left: 8px;
-  opacity: 0.6;
-}
-
-.model-link:hover {
-  text-decoration: underline;
-  opacity: 1;
-}
-
-/* -- Connect row -- */
-.connect-row {
-  display: flex;
-  gap: 10px;
-  align-items: flex-end;
-  flex-wrap: wrap;
-  margin-top: 16px;
-}
-
-.connect-row .api-field {
-  flex: 1 1 280px;
-}
-
-.connect-row .btn-group {
-  display: flex;
-  gap: 8px;
-  flex-shrink: 0;
-  padding-bottom: 1px;
-}
-
-/* -- Secondary button -- */
-button.secondary {
-  background: var(--secondary);
-  color: var(--foreground);
-  border: 1px solid var(--border);
-  box-shadow: none;
-}
-
-/* -- Transcript display -- */
-.transcript-wrap {
-  margin-top: 16px;
-  padding: 16px;
-  border-radius: calc(var(--radius) * 2);
-  background: var(--secondary);
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  box-shadow: 0 12px 24px rgba(21, 18, 13, 0.12);
-  min-height: 120px;
-  max-height: 400px;
-  overflow-y: auto;
-}
-
-.transcript-wrap .transcript-label {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--muted-foreground);
-  margin-bottom: 8px;
-  font-weight: 600;
-}
-
-.transcript-final {
-  font-size: 1.05rem;
-  line-height: 1.6;
-  color: var(--foreground);
-}
-
-.transcript-partial {
-  font-size: 1.05rem;
-  line-height: 1.6;
-  color: var(--muted-foreground);
-  font-style: italic;
-}
-
-.transcript-empty {
-  font-size: 0.95rem;
-  color: var(--muted-foreground);
-  font-style: italic;
-}
-
-.transcript-actions {
-  display: flex;
-  gap: 8px;
-  margin-top: 8px;
-  justify-content: flex-end;
-}
-
-.transcript-actions button {
-  font-size: 0.72rem;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: var(--card);
-  color: var(--muted-foreground);
-  border: 1px solid var(--border);
-  box-shadow: none;
-  cursor: pointer;
-  font-weight: 500;
-  transition: color 0.15s, border-color 0.15s;
-}
-
-.transcript-actions button:hover {
-  color: var(--foreground);
-  border-color: var(--foreground);
-}
-
-/* -- File input area -- */
-.file-input-area {
-  margin-top: 12px;
-  padding: 24px;
-  border: 2px dashed var(--border);
-  border-radius: var(--radius);
-  text-align: center;
-  cursor: pointer;
-  transition: border-color 0.15s, background 0.15s;
-}
-
-.file-input-area:hover {
-  border-color: var(--accent);
-  background: color-mix(in srgb, var(--accent) 5%, transparent);
-}
-
-.file-input-area.has-file {
-  border-style: solid;
-  border-color: var(--accent);
-}
-
-.file-input-area input[type="file"] {
-  display: none;
-}
-
-.file-input-area p {
-  margin: 0;
-  font-size: 0.9rem;
-}
-
-.file-input-area .file-name {
-  color: var(--foreground);
-  font-weight: 600;
-  margin-top: 4px;
-}
-
-/* -- URL input -- */
-.url-input-row {
-  margin-top: 12px;
-}
-
-/* -- Waveform -- */
-.waveform-wrap {
-  margin-top: 16px;
-  border-radius: calc(var(--radius) * 2);
-  background: var(--secondary);
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  box-shadow: 0 12px 24px rgba(21, 18, 13, 0.12);
-  overflow: hidden;
-}
-
-.waveform-wrap canvas {
-  width: 100%;
-  height: 80px;
-  display: block;
-}
-
-/* -- Status bar -- */
-.status-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 14px;
-  padding: 8px 12px;
-  border-radius: var(--radius);
-  background: var(--secondary);
-  font-size: 0.85rem;
-  color: var(--muted-foreground);
-}
-
-.status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--border);
-  flex-shrink: 0;
-}
-
-.status-bar.connected .status-dot {
-  background: var(--accent);
-}
-
-.status-bar.ready .status-dot {
-  background: var(--accent);
-  animation: pulse 1.8s ease-out infinite;
-}
-
-.status-bar.error .status-dot {
-  background: #ef4444;
-}
-
-.status-bar.error {
-  color: #ef4444;
-  background: #fef1f0;
-}
-
-/* -- Log console -- */
-.log-section {
-  margin-top: 12px;
-}
-
-.log-toggle {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.8rem;
-  color: var(--muted-foreground);
-  cursor: pointer;
-  border: none;
-  background: none;
-  padding: 4px 0;
-  font-weight: 500;
-  box-shadow: none;
-}
-
-.log-toggle:hover {
-  color: var(--foreground);
-}
-
-.log-toggle:disabled {
-  background: none;
-}
-
-.log-toggle .arrow {
-  transition: transform 0.15s;
-  font-size: 0.7rem;
-}
-
-.log-toggle.open .arrow {
-  transform: rotate(90deg);
-}
-
-.log {
-  margin-top: 6px;
-  padding: 10px 12px;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: var(--secondary);
-  font-size: 0.78rem;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  color: var(--muted-foreground);
-  max-height: 160px;
-  overflow-y: auto;
-  white-space: pre-wrap;
-  word-break: break-all;
-  display: none;
-}
-
-.log.open {
-  display: block;
-}
-
-/* -- Code samples -- */
-.code-samples {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 14px;
-  margin-top: 14px;
-}
 
-@media (min-width: 768px) {
-  .code-samples {
-    grid-template-columns: 1fr 1fr;
+  --border: #e3e2df;
+  --input: #e3e2df;
+  --ring: #15120d;
+
+  --radius: 0.375rem;
+
+  /* Brand tokens (from Figma) */
+  --brand-paper: #f3f2ed;
+  --brand-cream: #fbfaf7;
+  --brand-ink: #15120d;
+  --brand-stone: #5e5e59;
+  --brand-rule: #e3e2df;
+  --brand-yellow: #fbe566;
+  --brand-blue: #0973dc;
+}
+
+.dark {
+  --background: #1a1814;
+  --foreground: #f5f4f1;
+
+  --card: #1a1814;
+  --card-foreground: #f5f4f1;
+
+  --popover: #1a1814;
+  --popover-foreground: #f5f4f1;
+
+  --primary: #f5f4f1;
+  --primary-foreground: #1a1814;
+
+  --secondary: #252320;
+  --secondary-foreground: #f5f4f1;
+
+  --muted: #252320;
+  --muted-foreground: #a0a09b;
+
+  --accent: #252320;
+  --accent-foreground: #f5f4f1;
+
+  --destructive: 0 63% 31%;
+  --destructive-foreground: #f5f4f1;
+
+  --border: #333230;
+  --input: #333230;
+  --ring: #f5f4f1;
+}
+
+/* ── Map tokens to Tailwind v4 utilities ── */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  --color-brand-yellow: var(--brand-yellow);
+  --color-brand-blue: var(--brand-blue);
+
+  --radius-sm: calc(var(--radius) - 2px);
+  --radius-md: var(--radius);
+  --radius-lg: calc(var(--radius) + 2px);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --font-sans: var(--font-geist-sans), system-ui, -apple-system, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+@layer base {
+  * {
+    border-color: var(--border);
   }
-  .code-card.wide {
-    grid-column: 1 / -1;
+
+  body {
+    background-color: var(--background);
+    color: var(--foreground);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }
 
-.code-card {
-  background: var(--secondary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 12px;
-  overflow: hidden;
-}
-
-.code-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 8px;
-}
-
-.code-card h3 {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--muted-foreground);
-  margin: 0;
-}
-
-.copy-btn {
-  font-size: 0.72rem;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: var(--card);
-  color: var(--muted-foreground);
-  border: 1px solid var(--border);
-  box-shadow: none;
-  cursor: pointer;
-  font-weight: 500;
-  transition: color 0.15s, border-color 0.15s;
-}
-
-.copy-btn:hover {
-  color: var(--foreground);
-  border-color: var(--foreground);
-}
-
-/* -- Hidden utility -- */
-.hidden {
-  display: none !important;
-}
-
-details {
-  margin-top: 18px;
-  border-top: 1px dashed var(--border);
-  padding-top: 14px;
-}
-
-summary {
-  cursor: pointer;
-  font-weight: 600;
-  color: var(--muted-foreground);
-  list-style: none;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 10px;
-}
-
-summary::-webkit-details-marker {
-  display: none;
-}
-
-summary::before {
-  content: "";
-  width: 0;
-  height: 0;
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-top: 7px solid var(--muted-foreground);
-  transform: rotate(-90deg);
-  transition: transform 0.2s ease;
-}
-
-details[open] summary::before {
-  transform: rotate(0deg);
-}
-
-pre {
-  margin: 0;
-  white-space: pre-wrap;
-  font-size: 0.85rem;
-  color: var(--foreground);
-}
-
-.page-footer {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 14px;
-  font-size: 0.85rem;
-  color: var(--muted-foreground);
-  padding: 12px 4px 0;
-  border-top: 1px solid
-    color-mix(in srgb, var(--border) 70%, transparent);
-  text-align: center;
-}
-
-.footer-stack {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-}
-
-.footer-link {
-  color: var(--foreground);
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.footer-link:hover {
-  text-decoration: underline;
-}
-
-.h100-saans-bold {
-  --tw-leading: 110%;
-  --tw-font-weight: 790;
-  font-family: "Saans TRIAL", var(--font-body);
-  font-size: 42px;
-  font-weight: 790;
-  line-height: 110%;
-}
-
-@media (min-width: 768px) {
-  .h100-saans-bold {
-    font-size: 62px;
-  }
-}
-
-@keyframes wave {
+/* Soft pulsing dot used on the primary action / live indicators. */
+@keyframes slng-pulse {
   0% {
-    background-position: 0% 50%;
-  }
-  100% {
-    background-position: 200% 50%;
-  }
-}
-
-@keyframes pulse {
-  0% {
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--brand-yellow) 55%, transparent);
   }
   70% {
-    box-shadow: 0 0 0 10px transparent;
+    box-shadow: 0 0 0 8px transparent;
   }
   100% {
     box-shadow: 0 0 0 0 transparent;
   }
+}
+
+.animate-slng-pulse {
+  animation: slng-pulse 1.8s ease-out infinite;
 }

--- a/slng-stt-next/app/layout.tsx
+++ b/slng-stt-next/app/layout.tsx
@@ -23,8 +23,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" data-theme="light">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html lang="en">
+      <body className={`${geistSans.variable} ${geistMono.variable} font-sans`}>
         {children}
       </body>
     </html>

--- a/slng-stt-next/app/page.tsx
+++ b/slng-stt-next/app/page.tsx
@@ -1,11 +1,19 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
 import { StatusBar } from "./components/StatusBar";
 import { WaveformCanvas } from "./components/WaveformCanvas";
 import { LogConsole } from "./components/LogConsole";
 import { CodeBlock } from "./components/CodeBlock";
 import { TranscriptDisplay } from "./components/TranscriptDisplay";
+import { Button } from "./components/ui/button";
+import { Card } from "./components/ui/card";
+import { Input } from "./components/ui/input";
+import { Label } from "./components/ui/label";
+import { Tabs, TabsList, TabsTrigger } from "./components/ui/tabs";
+import { Textarea } from "./components/ui/textarea";
+import { cn } from "./components/ui/lib/utils";
 import { useSessionLog } from "./hooks/useSessionLog";
 import { useWebSocket } from "./hooks/useWebSocket";
 import { useWebAudio } from "./hooks/useWebAudio";
@@ -26,6 +34,50 @@ import { getProtocol } from "./lib/protocols";
 
 type InputSource = "microphone" | "file" | "url";
 type ConnectionMode = "websocket" | "http";
+
+// Native <select> styled to match the design system's Select trigger. Native is
+// kept so the demo stays copy-paste simple and supports <optgroup>.
+const selectClass =
+  "flex h-10 w-full appearance-none items-center rounded-md border border-input bg-background px-3 py-2 pr-8 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+const detailsClass = "mt-4 border-t border-border pt-4";
+const summaryClass =
+  "cursor-pointer text-sm font-medium text-muted-foreground transition-colors hover:text-foreground";
+
+function SelectShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative">
+      {children}
+      <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 opacity-50" />
+    </div>
+  );
+}
+
+function FieldLabel({
+  htmlFor,
+  children,
+  linkHref,
+  linkText,
+}: {
+  htmlFor: string;
+  children: React.ReactNode;
+  linkHref: string;
+  linkText: string;
+}) {
+  return (
+    <div className="mb-2 flex items-center justify-between gap-2">
+      <Label htmlFor={htmlFor}>{children}</Label>
+      <a
+        className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        href={linkHref}
+        target="_blank"
+        rel="noopener"
+      >
+        {linkText}
+      </a>
+    </div>
+  );
+}
 
 export default function Home() {
   // -- Mode --
@@ -682,81 +734,77 @@ export default function Home() {
   }, [model]);
 
   return (
-    <div className="page">
-      <header className="page-header">
-        <div className="brand">
-          <div className="logo">
+    <div className="mx-auto grid max-w-[920px] gap-5 px-4 py-9">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="grid h-11 w-11 place-items-center rounded-xl bg-brand-yellow">
             <img
               src="https://www.datocms-assets.com/182222/1763142110-logo.svg"
               alt="SLNG"
+              className="h-7 w-7"
             />
           </div>
           <div>
-            <p className="brand-title">SLNG</p>
-            <span className="brand-subtitle">STT Demo</span>
+            <p className="m-0 text-lg font-semibold uppercase tracking-wider">SLNG</p>
+            <span className="text-xs uppercase tracking-wider text-muted-foreground">
+              STT Demo
+            </span>
           </div>
         </div>
       </header>
 
-      <div className={`card ${isRecording ? "is-recording" : ""}`}>
-        <h1>SLNG STT Demo</h1>
-        <p>Speak, upload a file, or paste a URL to transcribe.</p>
+      <Card
+        className={cn(
+          "p-6 transition-shadow",
+          isRecording && "ring-1 ring-brand-yellow/60"
+        )}
+      >
+        <h1 className="m-0 text-2xl font-semibold tracking-tight">SLNG STT Demo</h1>
+        <p className="mb-5 mt-1 text-sm text-muted-foreground">
+          Speak, upload a file, or paste a URL to transcribe.
+        </p>
 
         {/* Connection mode toggle */}
-        <div className="mode-toggle">
-          <button
-            type="button"
-            className={connectionMode === "websocket" ? "active" : ""}
-            onClick={() => handleModeChange("websocket")}
-          >
-            WebSocket
-          </button>
-          <button
-            type="button"
-            className={connectionMode === "http" ? "active" : ""}
-            onClick={() => handleModeChange("http")}
-          >
-            HTTP
-          </button>
-        </div>
+        <Tabs
+          value={connectionMode}
+          onValueChange={(v) => handleModeChange(v as ConnectionMode)}
+        >
+          <TabsList>
+            <TabsTrigger value="websocket">WebSocket</TabsTrigger>
+            <TabsTrigger value="http">HTTP</TabsTrigger>
+          </TabsList>
+        </Tabs>
 
         {/* Input source toggle (WS only — HTTP is always file) */}
         {isWs && (
-          <div className="input-source-toggle">
-            <button
-              type="button"
-              className={inputSource === "microphone" ? "active" : ""}
-              onClick={() => setInputSource("microphone")}
+          <div className="mt-3">
+            <Tabs
+              value={inputSource}
+              onValueChange={(v) => setInputSource(v as InputSource)}
             >
-              Microphone
-            </button>
-            <button
-              type="button"
-              className={inputSource === "file" ? "active" : ""}
-              onClick={() => setInputSource("file")}
-            >
-              File
-            </button>
-            <button
-              type="button"
-              className={inputSource === "url" ? "active" : ""}
-              onClick={() => setInputSource("url")}
-            >
-              URL
-            </button>
+              <TabsList>
+                <TabsTrigger value="microphone">Microphone</TabsTrigger>
+                <TabsTrigger value="file">File</TabsTrigger>
+                <TabsTrigger value="url">URL</TabsTrigger>
+              </TabsList>
+            </Tabs>
           </div>
         )}
 
         {/* File input */}
         {(inputSource === "file" || connectionMode === "http") && (
           <div
-            className={`file-input-area ${selectedFile ? "has-file" : ""}`}
+            className={cn(
+              "mt-4 cursor-pointer rounded-lg border border-dashed border-border bg-secondary px-4 py-8 text-center text-sm text-muted-foreground transition-colors hover:border-foreground/40",
+              selectedFile && "border-brand-yellow/60"
+            )}
             onClick={() => fileInputRef.current?.click()}
           >
             <input
               ref={fileInputRef}
               type="file"
               accept="audio/*"
+              className="hidden"
               onChange={(e) => {
                 const file = e.target.files?.[0] || null;
                 setSelectedFile(file);
@@ -765,20 +813,22 @@ export default function Home() {
             />
             {selectedFile ? (
               <>
-                <p>Selected file:</p>
-                <p className="file-name">{selectedFile.name}</p>
+                <p className="m-0">Selected file:</p>
+                <p className="m-0 mt-1 font-medium text-foreground">{selectedFile.name}</p>
               </>
             ) : (
-              <p>Click to select an audio file (MP3, WAV, FLAC, OGG, WebM)</p>
+              <p className="m-0">Click to select an audio file (MP3, WAV, FLAC, OGG, WebM)</p>
             )}
           </div>
         )}
 
         {/* URL input */}
         {inputSource === "url" && isWs && (
-          <div className="url-input-row">
-            <label htmlFor="audioUrlInput">Audio URL</label>
-            <input
+          <div className="mt-4">
+            <Label htmlFor="audioUrlInput" className="mb-2 block">
+              Audio URL
+            </Label>
+            <Input
               id="audioUrlInput"
               type="url"
               placeholder="https://example.com/audio.wav"
@@ -789,66 +839,66 @@ export default function Home() {
         )}
 
         {/* Model / Language selectors */}
-        <div className="model-row">
-          <div className="field">
-            <label htmlFor="modelSelect">
+        <div className="mt-5 flex flex-wrap gap-3">
+          <div className="flex-1 basis-[280px]">
+            <FieldLabel
+              htmlFor="modelSelect"
+              linkHref="https://docs.slng.ai/models"
+              linkText="Discover models →"
+            >
               Model
-              <a
-                className="model-link"
-                href="https://docs.slng.ai/models"
-                target="_blank"
-                rel="noopener"
+            </FieldLabel>
+            <SelectShell>
+              <select
+                id="modelSelect"
+                className={selectClass}
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
               >
-                Discover models &rarr;
-              </a>
-            </label>
-            <select
-              id="modelSelect"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-            >
-              {modelGroups.map((group) => (
-                <optgroup key={group.label} label={group.label}>
-                  {group.options.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </optgroup>
-              ))}
-            </select>
+                {modelGroups.map((group) => (
+                  <optgroup key={group.label} label={group.label}>
+                    {group.options.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </SelectShell>
           </div>
-          <div className="field">
-            <label htmlFor="languageSelect">Language</label>
-            <select
-              id="languageSelect"
-              value={language}
-              onChange={(e) => setLanguage(e.target.value)}
-            >
-              {currentLanguageOptions.map((opt) => (
-                <option key={opt.value} value={opt.value}>
-                  {opt.label}
-                </option>
-              ))}
-            </select>
+          <div className="flex-1 basis-[280px]">
+            <Label htmlFor="languageSelect" className="mb-2 block">
+              Language
+            </Label>
+            <SelectShell>
+              <select
+                id="languageSelect"
+                className={selectClass}
+                value={language}
+                onChange={(e) => setLanguage(e.target.value)}
+              >
+                {currentLanguageOptions.map((opt) => (
+                  <option key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </option>
+                ))}
+              </select>
+            </SelectShell>
           </div>
         </div>
 
         {/* Connect row */}
-        <div className="connect-row">
-          <div className="api-field">
-            <label htmlFor="apiKeyInput">
+        <div className="mt-5 flex flex-wrap items-end gap-3">
+          <div className="flex-1 basis-[280px]">
+            <FieldLabel
+              htmlFor="apiKeyInput"
+              linkHref="https://app.slng.ai"
+              linkText="Get API key →"
+            >
               API Key
-              <a
-                className="model-link"
-                href="https://app.slng.ai"
-                target="_blank"
-                rel="noopener"
-              >
-                Get API key &rarr;
-              </a>
-            </label>
-            <input
+            </FieldLabel>
+            <Input
               id="apiKeyInput"
               type="password"
               placeholder="Paste your SLNG API key"
@@ -857,27 +907,29 @@ export default function Home() {
               onChange={(e) => setApiKey(e.target.value)}
             />
           </div>
-          <div className="btn-group">
+          <div className="flex shrink-0 gap-2">
             {isWs && (
-              <button
-                type="button"
-                className="secondary"
-                onClick={handleConnect}
-              >
+              <Button type="button" variant="secondary" onClick={handleConnect}>
                 {isConnected ? "Disconnect" : "Connect"}
-              </button>
+              </Button>
             )}
-            <button
+            <Button
               type="button"
-              className={`hero-button ${isBusy ? "is-loading" : ""} ${
-                isRecording ? "is-recording" : ""
-              } ${isActionDisabled ? "is-disabled" : ""}`}
               onClick={handleAction}
               disabled={isActionDisabled}
+              className={cn(isRecording && "bg-destructive text-destructive-foreground hover:bg-destructive/90")}
             >
-              <span className="pulse" aria-hidden="true"></span>
+              {!isActionDisabled && (
+                <span
+                  aria-hidden="true"
+                  className={cn(
+                    "h-2.5 w-2.5 rounded-full animate-slng-pulse",
+                    isRecording ? "bg-destructive-foreground" : "bg-brand-yellow"
+                  )}
+                />
+              )}
               {actionButtonLabel}
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -916,9 +968,9 @@ export default function Home() {
         <LogConsole entries={entries} onClear={clearLog} />
 
         {/* How to implement */}
-        <details>
-          <summary>How to implement</summary>
-          <div className="code-samples">
+        <details className={detailsClass}>
+          <summary className={summaryClass}>How to implement</summary>
+          <div className="mt-3 grid grid-cols-1 gap-3.5 md:grid-cols-2">
             {!isWs && (
               <>
                 <CodeBlock
@@ -1156,76 +1208,85 @@ function flush(ws) {
 
         {/* Advanced settings (WS only) */}
         {isWs && (
-          <details>
-            <summary>Advanced settings</summary>
-            <div className="row" style={{ marginTop: 12 }}>
-              <div style={{ flex: 1 }}>
-                <label htmlFor="wsUrlInput">WebSocket URL</label>
-                <input
+          <details className={detailsClass}>
+            <summary className={summaryClass}>Advanced settings</summary>
+            <div className="mt-3 flex flex-wrap items-end gap-3">
+              <div className="flex-1 basis-[280px]">
+                <Label htmlFor="wsUrlInput" className="mb-2 block">
+                  WebSocket URL
+                </Label>
+                <Input
                   id="wsUrlInput"
                   type="text"
                   value={wsUrl}
                   onChange={(e) => setWsUrl(e.target.value)}
                 />
               </div>
-              <div style={{ flex: "0 0 200px", alignSelf: "flex-end" }}>
-                <label htmlFor="urlPattern">URL pattern</label>
-                <select
-                  id="urlPattern"
-                  value={useDirectUrl ? "direct" : "bridge"}
-                  onChange={(e) => setUseDirectUrl(e.target.value === "direct")}
-                  disabled={isSarvam}
-                  title={isSarvam ? "Sarvam Saaras v3 only has a direct WebSocket channel." : undefined}
-                >
-                  <option value="bridge">Bridge (/v1/bridges/unmute/stt/)</option>
-                  <option value="direct">Direct (/v1/stt/)</option>
-                </select>
+              <div className="basis-[200px]">
+                <Label htmlFor="urlPattern" className="mb-2 block">
+                  URL pattern
+                </Label>
+                <SelectShell>
+                  <select
+                    id="urlPattern"
+                    className={cn(selectClass, "disabled:cursor-not-allowed disabled:opacity-50")}
+                    value={useDirectUrl ? "direct" : "bridge"}
+                    onChange={(e) => setUseDirectUrl(e.target.value === "direct")}
+                    disabled={isSarvam}
+                    title={isSarvam ? "Sarvam Saaras v3 only has a direct WebSocket channel." : undefined}
+                  >
+                    <option value="bridge">Bridge (/v1/bridges/unmute/stt/)</option>
+                    <option value="direct">Direct (/v1/stt/)</option>
+                  </select>
+                </SelectShell>
               </div>
             </div>
 
-            <div className="row">
-              <div>
-                <label htmlFor="proxyUrlInput">Proxy WebSocket URL</label>
-                <input
+            <div className="mt-3 flex flex-wrap items-end gap-3">
+              <div className="flex-1 basis-[280px]">
+                <Label htmlFor="proxyUrlInput" className="mb-2 block">
+                  Proxy WebSocket URL
+                </Label>
+                <Input
                   id="proxyUrlInput"
                   type="text"
                   value={proxyUrl}
                   onChange={(e) => setProxyUrl(e.target.value)}
                 />
               </div>
-              <div style={{ flex: "0 0 180px", alignSelf: "flex-end" }}>
-                <label
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 8,
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={useProxy}
-                    onChange={(e) => setUseProxy(e.target.checked)}
-                  />
-                  Use proxy
-                </label>
-              </div>
+              <label className="flex h-10 items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 accent-primary"
+                  checked={useProxy}
+                  onChange={(e) => setUseProxy(e.target.checked)}
+                />
+                Use proxy
+              </label>
             </div>
 
-            <div className="row">
-              <div>
-                <label htmlFor="encodingSelect">Encoding</label>
-                <select
-                  id="encodingSelect"
-                  value={encoding}
-                  onChange={(e) => setEncoding(e.target.value)}
-                >
-                  <option value="linear16">Linear16 (PCM)</option>
-                  <option value="pcm_mulaw">PCM mu-law</option>
-                </select>
+            <div className="mt-3 flex flex-wrap items-end gap-3">
+              <div className="flex-1 basis-[180px]">
+                <Label htmlFor="encodingSelect" className="mb-2 block">
+                  Encoding
+                </Label>
+                <SelectShell>
+                  <select
+                    id="encodingSelect"
+                    className={selectClass}
+                    value={encoding}
+                    onChange={(e) => setEncoding(e.target.value)}
+                  >
+                    <option value="linear16">Linear16 (PCM)</option>
+                    <option value="pcm_mulaw">PCM mu-law</option>
+                  </select>
+                </SelectShell>
               </div>
-              <div>
-                <label htmlFor="sampleRateInput">Sample rate</label>
-                <input
+              <div className="flex-1 basis-[180px]">
+                <Label htmlFor="sampleRateInput" className="mb-2 block">
+                  Sample rate
+                </Label>
+                <Input
                   id="sampleRateInput"
                   type="text"
                   value={sampleRate}
@@ -1233,48 +1294,33 @@ function flush(ws) {
                   onChange={(e) => setSampleRate(e.target.value)}
                 />
               </div>
-              <div style={{ flex: "0 0 180px", alignSelf: "flex-end" }}>
-                <label
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 8,
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={enablePartials}
-                    onChange={(e) => setEnablePartials(e.target.checked)}
-                  />
-                  Partial transcripts
-                </label>
-              </div>
+              <label className="flex h-10 items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 accent-primary"
+                  checked={enablePartials}
+                  onChange={(e) => setEnablePartials(e.target.checked)}
+                />
+                Partial transcripts
+              </label>
             </div>
 
-            <div className="row">
-              <div style={{ flex: "0 0 180px", alignSelf: "flex-end" }}>
-                <label
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 8,
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={useCustomInit}
-                    onChange={(e) => setUseCustomInit(e.target.checked)}
-                  />
-                  Use custom init
-                </label>
-              </div>
-            </div>
-
-            <label htmlFor="customInitPayload" style={{ marginTop: 12 }}>
-              Custom init JSON
+            <label className="mt-3 flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                className="h-4 w-4 accent-primary"
+                checked={useCustomInit}
+                onChange={(e) => setUseCustomInit(e.target.checked)}
+              />
+              Use custom init
             </label>
-            <textarea
+
+            <Label htmlFor="customInitPayload" className="mb-2 mt-3 block">
+              Custom init JSON
+            </Label>
+            <Textarea
               id="customInitPayload"
+              className="font-mono"
               rows={6}
               spellCheck={false}
               value={customInitPayload}
@@ -1282,11 +1328,13 @@ function flush(ws) {
             />
           </details>
         )}
-      </div>
+      </Card>
 
-      <footer className="page-footer">
-        <div className="footer-stack">
-          <p className="h100-saans-bold">Unmuted.</p>
+      <footer className="flex flex-col items-center gap-4 border-t border-border pt-6 text-center text-sm text-muted-foreground">
+        <div className="flex flex-col items-center gap-4">
+          <p className="m-0 text-5xl font-extrabold tracking-tight text-foreground md:text-6xl">
+            Unmuted.
+          </p>
           <a href="https://slng.ai" target="_blank" rel="noopener">
             <img
               alt="SLNG"
@@ -1300,7 +1348,7 @@ function flush(ws) {
           </a>
         </div>
         <a
-          className="footer-link"
+          className="font-semibold text-foreground hover:underline"
           href="https://app.slng.ai"
           target="_blank"
           rel="noopener"

--- a/slng-stt-next/package-lock.json
+++ b/slng-stt-next/package-lock.json
@@ -8,21 +8,43 @@
       "name": "slng-stt-next",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.553.0",
         "next": "16.1.2",
         "prism-react-renderer": "^2.4.1",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.1.17",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/ws": "^8.18.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.2",
+        "tailwindcss": "^4.1.17",
         "tsx": "^4.21.0",
         "typescript": "^5",
         "ws": "^8.19.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1717,6 +1739,316 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
+      "integrity": "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.10.tgz",
+      "integrity": "sha512-ib0zvq2ZsAqKm5tRnqGJn3vOxSgIts5ToxsXT0q1S/GfLD1Zj7UOEnkw8u2w6sRmn47djpQWuSU1DCL1R29/yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.13.tgz",
+      "integrity": "sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.15.tgz",
+      "integrity": "sha512-kxc9gI6/HfcU4nfMMVS3AmQK414kbU1IE6UCJmMmxjhO3cRPXOyYnmvyKD+ODt7q56nRq9l7Wovi6uaGwKgMlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-roving-focus": "1.1.13",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1731,6 +2063,318 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-x64": "4.3.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
+      "integrity": "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.1",
+        "@tailwindcss/oxide": "4.3.1",
+        "postcss": "8.5.15",
+        "tailwindcss": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/postcss/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -1785,7 +2429,7 @@
       "version": "19.2.14",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1795,7 +2439,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2859,6 +3503,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2927,7 +3583,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -3056,8 +3712,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3103,6 +3759,20 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -4120,6 +4790,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -4730,6 +5407,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4857,6 +5544,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4901,6 +5861,25 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.553.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.553.0.tgz",
+      "integrity": "sha512-BRgX5zrWmNy/lkVAe0dXBgd7XQdZ3HTf+Hwe3c9WK6dqgnj9h+hxV+MDncM88xDWlCq27+TKvHGE70ViODNILw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4968,9 +5947,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -6079,6 +7058,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tinyglobby": {

--- a/slng-stt-next/package.json
+++ b/slng-stt-next/package.json
@@ -10,18 +10,27 @@
     "proxy": "tsx scripts/ws-proxy.ts"
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.553.0",
     "next": "16.1.2",
     "prism-react-renderer": "^2.4.1",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.17",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/ws": "^8.18.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.2",
+    "tailwindcss": "^4.1.17",
     "tsx": "^4.21.0",
     "typescript": "^5",
     "ws": "^8.19.0"

--- a/slng-stt-next/postcss.config.mjs
+++ b/slng-stt-next/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;

--- a/slng-tts-next/app/components/CodeBlock.tsx
+++ b/slng-tts-next/app/components/CodeBlock.tsx
@@ -20,12 +20,20 @@ export function CodeBlock({ code, language, title, wide }: CodeBlockProps) {
   };
 
   return (
-    <div className={`code-card ${wide ? "wide" : ""}`}>
-      <div className="code-card-header">
-        {title && <h3>{title}</h3>}
+    <div
+      className={`overflow-hidden rounded-md border border-border bg-secondary p-3 ${
+        wide ? "md:col-span-2" : ""
+      }`}
+    >
+      <div className="mb-2 flex items-center justify-between">
+        {title && (
+          <h3 className="m-0 font-mono text-xs uppercase tracking-wider text-muted-foreground">
+            {title}
+          </h3>
+        )}
         <button
           type="button"
-          className="copy-btn"
+          className="rounded-full border border-border bg-card px-2.5 py-1 text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
           onClick={handleCopy}
         >
           {copied ? "Copied!" : "Copy"}
@@ -33,7 +41,10 @@ export function CodeBlock({ code, language, title, wide }: CodeBlockProps) {
       </div>
       <Highlight theme={themes.nightOwl} code={code.trim()} language={language}>
         {({ style, tokens, getLineProps, getTokenProps }) => (
-          <pre style={{ ...style, margin: 0, padding: "12px", borderRadius: "var(--radius)", fontSize: "0.75rem", lineHeight: 1.5, overflowX: "auto" }}>
+          <pre
+            className="m-0 overflow-x-auto rounded-md p-3 font-mono text-xs leading-relaxed"
+            style={style}
+          >
             {tokens.map((line, i) => (
               <div key={i} {...getLineProps({ line })}>
                 {line.map((token, key) => (

--- a/slng-tts-next/app/components/LogConsole.tsx
+++ b/slng-tts-next/app/components/LogConsole.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useState } from "react";
+import { ChevronRight, Trash2 } from "lucide-react";
+import { cn } from "./ui/lib/utils";
 import type { LogEntry } from "../hooks/useSessionLog";
 
 type LogConsoleProps = {
@@ -12,45 +14,38 @@ export function LogConsole({ entries, onClear }: LogConsoleProps) {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <div className="log-section">
-      <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+    <div className="mt-3">
+      <div className="flex items-center gap-2">
         <button
-          className={`log-toggle ${isOpen ? "open" : ""}`}
           type="button"
+          className="flex items-center gap-1.5 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground"
           onClick={() => setIsOpen((prev) => !prev)}
         >
-          <span className="arrow">&#9654;</span> Log
+          <ChevronRight
+            className={cn("h-3.5 w-3.5 transition-transform", isOpen && "rotate-90")}
+          />
+          Log
         </button>
         {isOpen && entries.length > 0 && onClear && (
           <button
             type="button"
             onClick={onClear}
             title="Clear logs"
-            style={{
-              background: "transparent",
-              border: "none",
-              cursor: "pointer",
-              padding: 2,
-              lineHeight: 1,
-            }}
+            className="text-muted-foreground transition-colors hover:text-foreground"
           >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="var(--foreground, #333)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <polyline points="3 6 5 6 21 6" />
-              <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
-              <path d="M10 11v6" />
-              <path d="M14 11v6" />
-              <path d="M9 6V4a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v2" />
-            </svg>
+            <Trash2 className="h-3.5 w-3.5" />
           </button>
         )}
       </div>
-      <div className={`log ${isOpen ? "open" : ""}`}>
-        {entries.map((entry, i) => (
-          <div key={i}>
-            {entry.timestamp} {entry.message}
-          </div>
-        ))}
-      </div>
+      {isOpen && (
+        <div className="mt-1.5 max-h-40 overflow-y-auto whitespace-pre-wrap break-all rounded-md border border-border bg-secondary p-3 font-mono text-xs text-muted-foreground">
+          {entries.map((entry, i) => (
+            <div key={i}>
+              {entry.timestamp} {entry.message}
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/slng-tts-next/app/components/ModeToggle.tsx
+++ b/slng-tts-next/app/components/ModeToggle.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Tabs, TabsList, TabsTrigger } from "./ui/tabs";
+
 type ModeToggleProps = {
   currentMode: "rest" | "websocket";
   onModeChange: (mode: "rest" | "websocket") => void;
@@ -8,23 +10,20 @@ type ModeToggleProps = {
 
 export function ModeToggle({ currentMode, onModeChange, disableRest }: ModeToggleProps) {
   return (
-    <div className="mode-toggle">
-      <button
-        type="button"
-        className={currentMode === "rest" ? "active" : ""}
-        onClick={() => onModeChange("rest")}
-        disabled={disableRest}
-        title={disableRest ? "This model supports WebSocket only" : undefined}
-      >
-        REST
-      </button>
-      <button
-        type="button"
-        className={currentMode === "websocket" ? "active" : ""}
-        onClick={() => onModeChange("websocket")}
-      >
-        WebSocket
-      </button>
-    </div>
+    <Tabs
+      value={currentMode}
+      onValueChange={(v) => onModeChange(v as "rest" | "websocket")}
+    >
+      <TabsList>
+        <TabsTrigger
+          value="rest"
+          disabled={disableRest}
+          title={disableRest ? "This model supports WebSocket only" : undefined}
+        >
+          REST
+        </TabsTrigger>
+        <TabsTrigger value="websocket">WebSocket</TabsTrigger>
+      </TabsList>
+    </Tabs>
   );
 }

--- a/slng-tts-next/app/components/StatusBar.tsx
+++ b/slng-tts-next/app/components/StatusBar.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { cn } from "./ui/lib/utils";
+
 type StatusBarProps = {
   status: string;
   isError: boolean;
@@ -13,18 +15,27 @@ export function StatusBar({
   isConnected,
   isReady,
 }: StatusBarProps) {
-  let barClass = "status-bar";
-  if (isError) {
-    barClass += " error";
-  } else if (isReady) {
-    barClass += " ready";
-  } else if (isConnected) {
-    barClass += " connected";
-  }
-
   return (
-    <div className={barClass}>
-      <span className="status-dot" />
+    <div
+      className={cn(
+        "mt-4 flex items-center gap-2 rounded-md px-3 py-2 text-sm",
+        isError
+          ? "bg-destructive/10 text-destructive"
+          : "bg-secondary text-muted-foreground"
+      )}
+    >
+      <span
+        className={cn(
+          "h-2 w-2 shrink-0 rounded-full",
+          isError
+            ? "bg-destructive"
+            : isReady
+              ? "bg-brand-yellow animate-slng-pulse"
+              : isConnected
+                ? "bg-brand-yellow"
+                : "bg-border"
+        )}
+      />
       <span>{status}</span>
     </div>
   );

--- a/slng-tts-next/app/components/WaveformCanvas.tsx
+++ b/slng-tts-next/app/components/WaveformCanvas.tsx
@@ -98,8 +98,8 @@ export function WaveformCanvas({
   }, [analyserNode, isActive]);
 
   return (
-    <div className="waveform-wrap">
-      <canvas ref={canvasRef} />
+    <div className="mt-4 overflow-hidden rounded-lg border border-border bg-secondary">
+      <canvas ref={canvasRef} className="block h-20 w-full" />
     </div>
   );
 }

--- a/slng-tts-next/app/components/ui/badge.tsx
+++ b/slng-tts-next/app/components/ui/badge.tsx
@@ -1,0 +1,39 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import * as React from 'react';
+
+import { cn } from './lib/utils';
+
+const badgeVariants = cva(
+  'inline-flex items-center rounded-full border border-transparent px-2.5 py-0.5 text-xs font-normal font-mono tracking-[-0.072px] leading-4 transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground shadow',
+        secondary: 'bg-secondary text-secondary-foreground',
+        success: 'bg-emerald-500/10 text-emerald-600 ring-1 ring-inset ring-emerald-500/30',
+        warning: 'bg-amber-500/10 text-amber-600 ring-1 ring-inset ring-amber-500/30',
+        destructive: 'bg-destructive text-destructive-foreground',
+        outline: 'text-foreground',
+        // Outlined status variants with colored borders (matching Figma design - no background)
+        'status-active': 'bg-transparent text-emerald-700 border-emerald-700',
+        'status-pending': 'bg-transparent text-amber-600 border-amber-600',
+        'status-expired': 'bg-transparent text-red-600 border-red-600',
+        'status-revoked': 'bg-transparent text-muted-foreground border-muted-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+const Badge = React.forwardRef<HTMLDivElement, BadgeProps>(({ className, variant, ...props }, ref) => (
+  <div ref={ref} className={cn(badgeVariants({ variant }), className)} {...props} />
+));
+Badge.displayName = 'Badge';
+
+export { Badge, badgeVariants };

--- a/slng-tts-next/app/components/ui/button.tsx
+++ b/slng-tts-next/app/components/ui/button.tsx
@@ -1,0 +1,49 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from './lib/utils';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 rounded-md text-sm font-medium cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-10 px-4 py-2',
+        sm: 'h-9 rounded-md px-3',
+        lg: 'h-11 rounded-md px-8',
+        icon: 'h-10 w-10',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp className={cn(buttonVariants({ variant, size }), className)} ref={ref} {...props} />
+    );
+  }
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/slng-tts-next/app/components/ui/card.tsx
+++ b/slng-tts-next/app/components/ui/card.tsx
@@ -1,0 +1,51 @@
+import * as React from 'react';
+
+import { cn } from './lib/utils';
+
+const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn('rounded-xl border border-border bg-card text-card-foreground shadow-sm', className)}
+      {...props}
+    />
+  )
+);
+Card.displayName = 'Card';
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+  )
+);
+CardHeader.displayName = 'CardHeader';
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    <h3 ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+  )
+);
+CardTitle.displayName = 'CardTitle';
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => (
+    <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+  )
+);
+CardDescription.displayName = 'CardDescription';
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+  )
+);
+CardContent.displayName = 'CardContent';
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+  )
+);
+CardFooter.displayName = 'CardFooter';
+
+export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };

--- a/slng-tts-next/app/components/ui/input.tsx
+++ b/slng-tts-next/app/components/ui/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from './lib/utils';
+
+const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLInputElement>>(
+  ({ className, type = 'text', ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/slng-tts-next/app/components/ui/label.tsx
+++ b/slng-tts-next/app/components/ui/label.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import * as LabelPrimitive from '@radix-ui/react-label';
+
+import { cn } from './lib/utils';
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/slng-tts-next/app/components/ui/lib/utils.ts
+++ b/slng-tts-next/app/components/ui/lib/utils.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]): string {
+  return twMerge(clsx(inputs));
+}

--- a/slng-tts-next/app/components/ui/tabs.tsx
+++ b/slng-tts-next/app/components/ui/tabs.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+
+import { cn } from './lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn('inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground', className)}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=inactive]:opacity-50',
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn('mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2', className)}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/slng-tts-next/app/components/ui/textarea.tsx
+++ b/slng-tts-next/app/components/ui/textarea.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+import { cn } from './lib/utils';
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.TextareaHTMLAttributes<HTMLTextAreaElement>>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        ref={ref}
+        className={cn(
+          'flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea };

--- a/slng-tts-next/app/globals.css
+++ b/slng-tts-next/app/globals.css
@@ -1,712 +1,141 @@
+@import "tailwindcss";
+
+/* Class-based dark mode (matches the SLNG product design system). */
+@custom-variant dark (&:is(.dark *));
+
+/* ── Design tokens (Figma-exact, from slng-ai/frontend) ── */
 :root {
-  color-scheme: light;
   --background: #fbfaf7;
   --foreground: #15120d;
-  --card: #ffffff;
+
+  --card: #fffffd;
   --card-foreground: #15120d;
+
   --popover: #ffffff;
   --popover-foreground: #15120d;
+
   --primary: #15120d;
   --primary-foreground: #ffffff;
+
   --secondary: #f3f2ed;
   --secondary-foreground: #15120d;
+
   --muted: #f3f2ed;
-  --muted-foreground: #8a8983;
-  --accent: #fbe566;
+  --muted-foreground: #5e5e59;
+
+  --accent: #f3f2ed;
   --accent-foreground: #15120d;
-  --destructive: #ef4444;
+
+  --destructive: 0 84% 60%;
   --destructive-foreground: #ffffff;
-  --border: #cac9c4;
-  --input: #cac9c4;
-  --ring: #fbe566;
-  --radius: 0.5rem;
-  --font-body: ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
-  --shadow-soft: 0 24px 50px rgba(21, 18, 13, 0.12);
-}
-
-:root[data-theme="dark"] {
-  color-scheme: dark;
-  --background: #1a1a1a;
-  --foreground: #f3f2ed;
-  --card: #1f1f1f;
-  --card-foreground: #f3f2ed;
-  --popover: #1f1f1f;
-  --popover-foreground: #f3f2ed;
-  --primary: #fbe566;
-  --primary-foreground: #15120d;
-  --secondary: #2b2a25;
-  --secondary-foreground: #f3f2ed;
-  --muted: #23221e;
-  --muted-foreground: #cac9c4;
-  --accent: #43a1e1;
-  --accent-foreground: #ffffff;
-  --border: #2c2b26;
-  --input: #2c2b26;
-  --ring: #fbe566;
-}
-
-* {
-  box-sizing: border-box;
-  padding: 0;
-  margin: 0;
-}
-
-html {
-  scroll-behavior: smooth;
-}
-
-body {
-  min-height: 100vh;
-  background: var(--background);
-  color: var(--foreground);
-  font-family: var(--font-body);
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  background-image: radial-gradient(
-      circle at 20% 10%,
-      color-mix(in srgb, var(--accent) 40%, transparent),
-      transparent 65%
-    ),
-    radial-gradient(
-      circle at 80% 0%,
-      color-mix(in srgb, var(--secondary) 60%, transparent),
-      transparent 55%
-    );
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-
-button,
-input,
-select,
-textarea {
-  font: inherit;
-}
-
-.page {
-  max-width: 920px;
-  margin: 0 auto;
-  padding: 36px 18px 28px;
-  display: grid;
-  gap: 20px;
-}
-
-.page-header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.brand {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-}
-
-.logo {
-  width: 46px;
-  height: 46px;
-  border-radius: 16px;
-  display: grid;
-  place-items: center;
-  background: var(--accent);
-  color: var(--accent-foreground);
-  box-shadow: inset 0 0 0 1px
-    color-mix(in srgb, var(--foreground) 20%, transparent);
-}
-
-.logo img {
-  width: 28px;
-  height: 28px;
-  display: block;
-}
-
-.brand-title {
-  font-size: 1.35rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  margin: 0;
-}
-
-.brand-subtitle {
-  display: block;
-  font-size: 0.85rem;
-  color: var(--muted-foreground);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-}
-
-.card {
-  background: var(--card);
-  color: var(--card-foreground);
-  border: 1px solid var(--border);
-  border-radius: calc(var(--radius) * 2);
-  padding: 24px;
-  box-shadow: var(--shadow-soft);
-}
-
-.card.is-playing {
-  border-color: color-mix(in srgb, var(--accent) 65%, var(--border));
-  box-shadow: 0 28px 60px rgba(21, 18, 13, 0.18);
-}
-
-h1 {
-  font-size: 2rem;
-  margin: 0 0 12px;
-}
-
-p {
-  margin: 0 0 16px;
-  color: var(--muted-foreground);
-}
-
-label {
-  font-weight: 600;
-  display: block;
-  margin: 12px 0 8px;
-}
-
-textarea,
-input[type="password"],
-input[type="text"],
-select {
-  width: 100%;
-  padding: 12px;
-  border-radius: var(--radius);
-  border: 1px solid var(--input);
-  font-size: 0.98rem;
-  background: var(--popover);
-  color: var(--popover-foreground);
-}
-
-textarea {
-  min-height: 120px;
-  resize: vertical;
-}
-
-.row {
-  display: flex;
-  gap: 12px;
-  flex-wrap: wrap;
-  margin-top: 16px;
-}
-
-.row > * {
-  flex: 1 1 240px;
-}
-
-.prompt-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 10px;
-  margin-top: 12px;
-}
-
-.chip {
-  border: 1px solid var(--border);
-  background: var(--secondary);
-  color: var(--secondary-foreground);
-  padding: 6px 12px;
-  border-radius: 999px;
-  font-size: 0.85rem;
-  cursor: pointer;
-}
-
-.chip:hover {
-  border-color: var(--accent);
-}
-
-button {
-  background: var(--primary);
-  color: var(--primary-foreground);
-  border: none;
-  padding: 12px 18px;
-  border-radius: 999px;
-  font-weight: 600;
-  cursor: pointer;
-  box-shadow: 0 10px 20px rgba(21, 18, 13, 0.2);
-}
-
-button:disabled {
-  cursor: not-allowed;
-}
- 
-.hero-button:disabled {
-  opacity: 1;
-  background: var(--muted);
-  color: var(--muted-foreground);
-  box-shadow: none;
-}
-
-.hero-button {
-  font-size: 1rem;
-  letter-spacing: 0.02em;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  min-height: 48px;
-}
-
-.hero-button .pulse {
-  display: inline-flex;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
-  background: var(--accent);
-  box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 60%, transparent);
-  animation: pulse 1.8s ease-out infinite;
-}
-
-.hero-button.is-loading .pulse {
-  animation: pulse 0.8s ease-in-out infinite;
-}
-
-.hero-button.is-disabled .pulse {
-  animation: none;
-  box-shadow: none;
-  opacity: 0;
-}
-
-button:focus-visible,
-input:focus-visible,
-textarea:focus-visible,
-select:focus-visible {
-  outline: 2px solid var(--ring);
-  outline-offset: 2px;
-}
-
-.cta-link {
-  display: inline-block;
-  margin-top: 10px;
-  color: var(--foreground);
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.cta-link:hover {
-  text-decoration: underline;
-}
-
-/* ── Mode toggle ── */
-.mode-toggle {
-  display: inline-flex;
-  background: var(--secondary);
-  border: 1px solid var(--border);
-  border-radius: 999px;
-  padding: 3px;
-  gap: 2px;
-  margin-bottom: 20px;
-}
-
-.mode-toggle button {
-  padding: 7px 16px;
-  border-radius: 999px;
-  font-size: 0.82rem;
-  font-weight: 600;
-  border: none;
-  cursor: pointer;
-  background: transparent;
-  color: var(--muted-foreground);
-  box-shadow: none;
-  transition: all 0.15s;
-  letter-spacing: 0.01em;
-}
-
-.mode-toggle button.active {
-  background: var(--card);
-  color: var(--foreground);
-  box-shadow: 0 1px 3px rgba(21, 18, 13, 0.1);
-}
-
-/* ── Model row ── */
-.model-row {
-  display: flex;
-  gap: 12px;
-  align-items: flex-end;
-  flex-wrap: wrap;
-  margin-top: 16px;
-}
-
-.model-row .field {
-  flex: 1 1 280px;
-}
-
-.model-link {
-  font-size: 0.8rem;
-  font-weight: 400;
-  color: var(--foreground);
-  text-decoration: none;
-  margin-left: 8px;
-  opacity: 0.6;
-}
-
-.model-link:hover {
-  text-decoration: underline;
-  opacity: 1;
-}
-
-/* ── Connect row ── */
-.connect-row {
-  display: flex;
-  gap: 10px;
-  align-items: flex-end;
-  flex-wrap: wrap;
-  margin-top: 16px;
-}
-
-.connect-row .api-field {
-  flex: 1 1 280px;
-}
-
-.connect-row .btn-group {
-  display: flex;
-  gap: 8px;
-  flex-shrink: 0;
-  padding-bottom: 1px;
-}
-
-/* ── Secondary button ── */
-button.secondary {
-  background: var(--secondary);
-  color: var(--foreground);
-  border: 1px solid var(--border);
-  box-shadow: none;
-}
-
-/* ── Audio wrap ── */
-.audio-wrap {
-  margin-top: 16px;
-  padding: 8px 12px;
-  border-radius: 999px;
-  background: var(--secondary);
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  box-shadow: 0 12px 24px rgba(21, 18, 13, 0.12);
-}
-
-.audio-wrap audio {
-  width: 100%;
-  display: block;
-  accent-color: var(--accent);
-}
-
-audio::-webkit-media-controls-panel {
-  background: transparent;
-}
-
-/* ── Waveform ── */
-.waveform-wrap {
-  margin-top: 16px;
-  border-radius: calc(var(--radius) * 2);
-  background: var(--secondary);
-  border: 1px solid color-mix(in srgb, var(--border) 70%, transparent);
-  box-shadow: 0 12px 24px rgba(21, 18, 13, 0.12);
-  overflow: hidden;
-}
-
-.waveform-wrap canvas {
-  width: 100%;
-  height: 80px;
-  display: block;
-}
-
-/* ── Status bar ── */
-.status-bar {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 14px;
-  padding: 8px 12px;
-  border-radius: var(--radius);
-  background: var(--secondary);
-  font-size: 0.85rem;
-  color: var(--muted-foreground);
-}
-
-.status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--border);
-  flex-shrink: 0;
-}
-
-.status-bar.connected .status-dot {
-  background: var(--accent);
-}
-
-.status-bar.ready .status-dot {
-  background: var(--accent);
-  animation: pulse 1.8s ease-out infinite;
-}
-
-.status-bar.error .status-dot {
-  background: #ef4444;
-}
-
-.status-bar.error {
-  color: #ef4444;
-  background: #fef1f0;
-}
-
-/* ── Log console ── */
-.log-section {
-  margin-top: 12px;
-}
-
-.log-toggle {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  font-size: 0.8rem;
-  color: var(--muted-foreground);
-  cursor: pointer;
-  border: none;
-  background: none;
-  padding: 4px 0;
-  font-weight: 500;
-  box-shadow: none;
-}
-
-.log-toggle:hover {
-  color: var(--foreground);
-}
-
-.log-toggle:disabled {
-  background: none;
-}
-
-.log-toggle .arrow {
-  transition: transform 0.15s;
-  font-size: 0.7rem;
-}
-
-.log-toggle.open .arrow {
-  transform: rotate(90deg);
-}
-
-.log {
-  margin-top: 6px;
-  padding: 10px 12px;
-  border-radius: var(--radius);
-  border: 1px solid var(--border);
-  background: var(--secondary);
-  font-size: 0.78rem;
-  font-family: ui-monospace, "SF Mono", Menlo, monospace;
-  color: var(--muted-foreground);
-  max-height: 160px;
-  overflow-y: auto;
-  white-space: pre-wrap;
-  word-break: break-all;
-  display: none;
-}
-
-.log.open {
-  display: block;
-}
-
-/* ── Code samples ── */
-.code-samples {
-  display: grid;
-  grid-template-columns: 1fr;
-  gap: 14px;
-  margin-top: 14px;
-}
 
-@media (min-width: 768px) {
-  .code-samples {
-    grid-template-columns: 1fr 1fr;
+  --border: #e3e2df;
+  --input: #e3e2df;
+  --ring: #15120d;
+
+  --radius: 0.375rem;
+
+  /* Brand tokens (from Figma) */
+  --brand-paper: #f3f2ed;
+  --brand-cream: #fbfaf7;
+  --brand-ink: #15120d;
+  --brand-stone: #5e5e59;
+  --brand-rule: #e3e2df;
+  --brand-yellow: #fbe566;
+  --brand-blue: #0973dc;
+}
+
+.dark {
+  --background: #1a1814;
+  --foreground: #f5f4f1;
+
+  --card: #1a1814;
+  --card-foreground: #f5f4f1;
+
+  --popover: #1a1814;
+  --popover-foreground: #f5f4f1;
+
+  --primary: #f5f4f1;
+  --primary-foreground: #1a1814;
+
+  --secondary: #252320;
+  --secondary-foreground: #f5f4f1;
+
+  --muted: #252320;
+  --muted-foreground: #a0a09b;
+
+  --accent: #252320;
+  --accent-foreground: #f5f4f1;
+
+  --destructive: 0 63% 31%;
+  --destructive-foreground: #f5f4f1;
+
+  --border: #333230;
+  --input: #333230;
+  --ring: #f5f4f1;
+}
+
+/* ── Map tokens to Tailwind v4 utilities ── */
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: hsl(var(--destructive));
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+
+  --color-brand-yellow: var(--brand-yellow);
+  --color-brand-blue: var(--brand-blue);
+
+  --radius-sm: calc(var(--radius) - 2px);
+  --radius-md: var(--radius);
+  --radius-lg: calc(var(--radius) + 2px);
+  --radius-xl: calc(var(--radius) + 4px);
+
+  --font-sans: var(--font-geist-sans), system-ui, -apple-system, sans-serif;
+  --font-mono: var(--font-geist-mono), ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+@layer base {
+  * {
+    border-color: var(--border);
   }
-  .code-card.wide {
-    grid-column: 1 / -1;
+
+  body {
+    background-color: var(--background);
+    color: var(--foreground);
+    font-family: var(--font-sans);
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
   }
 }
 
-.code-card {
-  background: var(--secondary);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 12px;
-  overflow: hidden;
-}
-
-.code-card-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 8px;
-}
-
-.code-card h3 {
-  font-size: 0.8rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--muted-foreground);
-  margin: 0;
-}
-
-.copy-btn {
-  font-size: 0.72rem;
-  padding: 4px 10px;
-  border-radius: 999px;
-  background: var(--card);
-  color: var(--muted-foreground);
-  border: 1px solid var(--border);
-  box-shadow: none;
-  cursor: pointer;
-  font-weight: 500;
-  transition: color 0.15s, border-color 0.15s;
-}
-
-.copy-btn:hover {
-  color: var(--foreground);
-  border-color: var(--foreground);
-}
-
-/* ── Hidden utility ── */
-.hidden {
-  display: none !important;
-}
-
-details {
-  margin-top: 18px;
-  border-top: 1px dashed var(--border);
-  padding-top: 14px;
-}
-
-summary {
-  cursor: pointer;
-  font-weight: 600;
-  color: var(--muted-foreground);
-  list-style: none;
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: 10px;
-}
-
-summary::-webkit-details-marker {
-  display: none;
-}
-
-summary::before {
-  content: "";
-  width: 0;
-  height: 0;
-  border-left: 6px solid transparent;
-  border-right: 6px solid transparent;
-  border-top: 7px solid var(--muted-foreground);
-  transform: rotate(-90deg);
-  transition: transform 0.2s ease;
-}
-
-details[open] summary::before {
-  transform: rotate(0deg);
-}
-
-.inspect {
-  margin-top: 18px;
-  padding-top: 14px;
-  border-top: 1px dashed var(--border);
-}
-
-.inspect-grid {
-  display: grid;
-  gap: 14px;
-  margin-top: 12px;
-}
-
-.inspect-card {
-  background: var(--secondary);
-  border-radius: var(--radius);
-  padding: 12px;
-  border: 1px solid var(--border);
-}
-
-.inspect-card h3 {
-  margin: 0 0 8px;
-  font-size: 0.95rem;
-  color: var(--muted-foreground);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-pre {
-  margin: 0;
-  white-space: pre-wrap;
-  font-size: 0.85rem;
-  color: var(--foreground);
-}
-
-.page-footer {
-  display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: center;
-  gap: 14px;
-  font-size: 0.85rem;
-  color: var(--muted-foreground);
-  padding: 12px 4px 0;
-  border-top: 1px solid
-    color-mix(in srgb, var(--border) 70%, transparent);
-  text-align: center;
-}
-
-.footer-stack {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-}
-
-.footer-link {
-  color: var(--foreground);
-  font-weight: 600;
-  text-decoration: none;
-}
-
-.footer-link:hover {
-  text-decoration: underline;
-}
-
-.h100-saans-bold {
-  --tw-leading: 110%;
-  --tw-font-weight: 790;
-  font-family: "Saans TRIAL", var(--font-body);
-  font-size: 42px;
-  font-weight: 790;
-  line-height: 110%;
-}
-
-@media (min-width: 768px) {
-  .h100-saans-bold {
-    font-size: 62px;
-  }
-}
-
-@keyframes wave {
+/* Soft pulsing dot used on the primary action / live indicators. */
+@keyframes slng-pulse {
   0% {
-    background-position: 0% 50%;
-  }
-  100% {
-    background-position: 200% 50%;
-  }
-}
-
-@keyframes pulse {
-  0% {
-    box-shadow: 0 0 0 0 color-mix(in srgb, var(--accent) 55%, transparent);
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--brand-yellow) 55%, transparent);
   }
   70% {
-    box-shadow: 0 0 0 10px transparent;
+    box-shadow: 0 0 0 8px transparent;
   }
   100% {
     box-shadow: 0 0 0 0 transparent;
   }
+}
+
+.animate-slng-pulse {
+  animation: slng-pulse 1.8s ease-out infinite;
 }

--- a/slng-tts-next/app/hooks/useWebAudio.ts
+++ b/slng-tts-next/app/hooks/useWebAudio.ts
@@ -56,10 +56,19 @@ export function useWebAudio(sampleRate: number) {
     nextPlayTimeRef.current = 0;
   }, []);
 
+  // Milliseconds of audio still scheduled to play. Because chunks are scheduled
+  // ahead of `currentTime`, playback continues after the server stops sending.
+  const getPlaybackRemainingMs = useCallback(() => {
+    const ctx = audioContextRef.current;
+    if (!ctx) return 0;
+    return Math.max(0, (nextPlayTimeRef.current - ctx.currentTime) * 1000);
+  }, []);
+
   return {
     playPcmChunk,
     closeAudio,
     resetPlayTime,
+    getPlaybackRemainingMs,
     analyserNodeRef,
     ensureAudioContext,
   };

--- a/slng-tts-next/app/layout.tsx
+++ b/slng-tts-next/app/layout.tsx
@@ -23,8 +23,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" data-theme="light">
-      <body className={`${geistSans.variable} ${geistMono.variable}`}>
+    <html lang="en">
+      <body className={`${geistSans.variable} ${geistMono.variable} font-sans`}>
         {children}
       </body>
     </html>

--- a/slng-tts-next/app/page.tsx
+++ b/slng-tts-next/app/page.tsx
@@ -1,11 +1,18 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
 import { ModeToggle } from "./components/ModeToggle";
 import { StatusBar } from "./components/StatusBar";
 import { WaveformCanvas } from "./components/WaveformCanvas";
 import { LogConsole } from "./components/LogConsole";
 import { CodeBlock } from "./components/CodeBlock";
+import { Button } from "./components/ui/button";
+import { Card } from "./components/ui/card";
+import { Input } from "./components/ui/input";
+import { Label } from "./components/ui/label";
+import { Textarea } from "./components/ui/textarea";
+import { cn } from "./components/ui/lib/utils";
 import { useSessionLog } from "./hooks/useSessionLog";
 import { useAudioBuffer } from "./hooks/useAudioBuffer";
 import { useWebAudio } from "./hooks/useWebAudio";
@@ -29,6 +36,51 @@ import {
   base64ToBytes,
   pcmToWav,
 } from "./lib/audio-utils";
+
+// Native <select> styled to match the design system's Select trigger. Native is
+// kept (rather than the Radix Select) so the demo stays copy-paste simple and
+// supports <optgroup> for the grouped model/voice lists.
+const selectClass =
+  "flex h-10 w-full appearance-none items-center rounded-md border border-input bg-background px-3 py-2 pr-8 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+
+const detailsClass = "mt-4 border-t border-border pt-4";
+const summaryClass =
+  "cursor-pointer text-sm font-medium text-muted-foreground transition-colors hover:text-foreground";
+
+function SelectShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="relative">
+      {children}
+      <ChevronDown className="pointer-events-none absolute right-3 top-1/2 h-4 w-4 -translate-y-1/2 opacity-50" />
+    </div>
+  );
+}
+
+function FieldLabel({
+  htmlFor,
+  children,
+  linkHref,
+  linkText,
+}: {
+  htmlFor: string;
+  children: React.ReactNode;
+  linkHref: string;
+  linkText: string;
+}) {
+  return (
+    <div className="mb-2 flex items-center justify-between gap-2">
+      <Label htmlFor={htmlFor}>{children}</Label>
+      <a
+        className="text-xs font-medium text-muted-foreground transition-colors hover:text-foreground"
+        href={linkHref}
+        target="_blank"
+        rel="noopener"
+      >
+        {linkText}
+      </a>
+    </div>
+  );
+}
 
 export default function Home() {
   // ── Mode ──
@@ -93,13 +145,22 @@ export default function Home() {
     const v = parseInt(sampleRate, 10);
     return Number.isFinite(v) && v > 0 ? v : 24000;
   }, [sampleRate]);
-  const { playPcmChunk, closeAudio, resetPlayTime, analyserNodeRef, ensureAudioContext } =
+  const { playPcmChunk, closeAudio, resetPlayTime, getPlaybackRemainingMs, analyserNodeRef, ensureAudioContext } =
     useWebAudio(parsedSampleRate);
   const { appendChunk, reset: resetAudioBuffer, scheduleFlush, markAudioEnd } =
     useAudioBuffer();
 
   // ── Audio chunk base64 accumulator (for JSON-based audio) ──
   const audioChunksBase64Ref = useRef("");
+
+  // Timer that keeps the waveform animating until scheduled playback ends.
+  const waveformStopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearWaveformStopTimer = useCallback(() => {
+    if (waveformStopTimerRef.current) {
+      clearTimeout(waveformStopTimerRef.current);
+      waveformStopTimerRef.current = null;
+    }
+  }, []);
 
   // ── Status helpers ──
   const setStatusMessage = useCallback((message: string, isError = false) => {
@@ -157,7 +218,13 @@ export default function Home() {
       ) {
         if (audioFormat === "linear16") {
           appendLog("Stream complete (streaming via Web Audio API).");
-          setWaveformActive(false);
+          // Audio is scheduled ahead of real time, so keep the waveform
+          // animating until the buffered playback actually finishes.
+          clearWaveformStopTimer();
+          waveformStopTimerRef.current = setTimeout(() => {
+            setWaveformActive(false);
+            waveformStopTimerRef.current = null;
+          }, getPlaybackRemainingMs() + 250);
         } else {
           markAudioEnd();
           scheduleFlush(handleBufferFlush);
@@ -219,6 +286,8 @@ export default function Home() {
       handleBufferFlush,
       appendChunk,
       playPcmChunk,
+      clearWaveformStopTimer,
+      getPlaybackRemainingMs,
     ]
   );
 
@@ -301,6 +370,7 @@ export default function Home() {
         closeAudio();
       }
       setCurrentMode(mode);
+      clearWaveformStopTimer();
       setWaveformActive(false);
       if (mode === "rest") {
         setStatusMessage("Enter your API key and press Say it.");
@@ -308,7 +378,7 @@ export default function Home() {
         setStatusMessage("Enter your API key and connect.");
       }
     },
-    [isConnected, disconnect, closeAudio, setStatusMessage]
+    [isConnected, disconnect, closeAudio, setStatusMessage, clearWaveformStopTimer]
   );
 
   // ── Connect / Disconnect ──
@@ -316,6 +386,7 @@ export default function Home() {
     if (isConnected) {
       disconnect();
       closeAudio();
+      clearWaveformStopTimer();
       setWaveformActive(false);
       return;
     }
@@ -388,6 +459,7 @@ export default function Home() {
     connect,
     setStatusMessage,
     appendLog,
+    clearWaveformStopTimer,
   ]);
 
   // ── Send WS payload ──
@@ -425,6 +497,7 @@ export default function Home() {
     }
 
     appendLog(`Sending payload: ${payload}`);
+    clearWaveformStopTimer();
     resetAudioBuffer();
     resetPlayTime();
     setWaveformActive(false);
@@ -435,6 +508,7 @@ export default function Home() {
     text,
     payloadMode,
     customPayload,
+    clearWaveformStopTimer,
     appendLog,
     resetAudioBuffer,
     resetPlayTime,
@@ -556,125 +630,134 @@ export default function Home() {
   }, [model, restPayload]);
 
   return (
-    <div className="page">
-      <header className="page-header">
-        <div className="brand">
-          <div className="logo">
+    <div className="mx-auto grid max-w-[920px] gap-5 px-4 py-9">
+      <header className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <div className="grid h-11 w-11 place-items-center rounded-xl bg-brand-yellow">
             <img
               src="https://www.datocms-assets.com/182222/1763142110-logo.svg"
               alt="SLNG"
+              className="h-7 w-7"
             />
           </div>
           <div>
-            <p className="brand-title">SLNG</p>
-            <span className="brand-subtitle">TTS Demo</span>
+            <p className="m-0 text-lg font-semibold uppercase tracking-wider">SLNG</p>
+            <span className="text-xs uppercase tracking-wider text-muted-foreground">
+              TTS Demo
+            </span>
           </div>
         </div>
       </header>
 
-      <div className={`card ${isPlaying ? "is-playing" : ""}`}>
-        <h1>SLNG TTS Demo</h1>
-        <p>Type something and hear it instantly.</p>
+      <Card
+        className={cn(
+          "p-6 transition-shadow",
+          isPlaying && "ring-1 ring-brand-yellow/60"
+        )}
+      >
+        <h1 className="m-0 text-2xl font-semibold tracking-tight">SLNG TTS Demo</h1>
+        <p className="mb-5 mt-1 text-sm text-muted-foreground">
+          Type something and hear it instantly.
+        </p>
 
         <ModeToggle currentMode={currentMode} onModeChange={handleModeChange} disableRest={isWsOnlyModel(model)} />
 
-        <label htmlFor="textInput">Text to synthesize</label>
-        <textarea
+        <Label htmlFor="textInput" className="mb-2 mt-5 block">
+          Text to synthesize
+        </Label>
+        <Textarea
           id="textInput"
           ref={textAreaRef}
+          className="min-h-[120px]"
           value={text}
           onChange={(e) => setText(e.target.value)}
           placeholder="Try: Welcome to SLNG."
         />
 
-        <div className="prompt-chips">
+        <div className="mt-3 flex flex-wrap gap-2">
           {promptSuggestions.map((suggestion) => (
-            <button
+            <Button
               key={suggestion.label}
-              className="chip"
+              variant="outline"
+              size="sm"
+              className="rounded-full"
               type="button"
               onClick={() => handleChipClick(suggestion)}
             >
               {suggestion.label}
-            </button>
+            </Button>
           ))}
         </div>
 
         {/* Model / Voice selectors */}
-        <div className="model-row">
-          <div className="field">
-            <label htmlFor="modelSelect">
+        <div className="mt-5 flex flex-wrap gap-3">
+          <div className="flex-1 basis-[280px]">
+            <FieldLabel
+              htmlFor="modelSelect"
+              linkHref="https://docs.slng.ai/models"
+              linkText="Discover models →"
+            >
               Model
-              <a
-                className="model-link"
-                href="https://docs.slng.ai/models"
-                target="_blank"
-                rel="noopener"
+            </FieldLabel>
+            <SelectShell>
+              <select
+                id="modelSelect"
+                className={selectClass}
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
               >
-                Discover models &rarr;
-              </a>
-            </label>
-            <select
-              id="modelSelect"
-              value={model}
-              onChange={(e) => setModel(e.target.value)}
-            >
-              {modelGroups.map((group) => (
-                <optgroup key={group.label} label={group.label}>
-                  {group.options.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </optgroup>
-              ))}
-            </select>
+                {modelGroups.map((group) => (
+                  <optgroup key={group.label} label={group.label}>
+                    {group.options.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </SelectShell>
           </div>
-          <div className="field">
-            <label htmlFor="voiceSelect">
-              Voice
-              <a
-                className="model-link"
-                href={voiceDocsUrl}
-                target="_blank"
-                rel="noopener"
-              >
-                Discover voices &rarr;
-              </a>
-            </label>
-            <select
-              id="voiceSelect"
-              value={voice}
-              onChange={(e) => setVoice(e.target.value)}
+          <div className="flex-1 basis-[280px]">
+            <FieldLabel
+              htmlFor="voiceSelect"
+              linkHref={voiceDocsUrl}
+              linkText="Discover voices →"
             >
-              {voiceGroups.map((group) => (
-                <optgroup key={group.label} label={group.label}>
-                  {group.options.map((opt) => (
-                    <option key={opt.value} value={opt.value}>
-                      {opt.label}
-                    </option>
-                  ))}
-                </optgroup>
-              ))}
-            </select>
+              Voice
+            </FieldLabel>
+            <SelectShell>
+              <select
+                id="voiceSelect"
+                className={selectClass}
+                value={voice}
+                onChange={(e) => setVoice(e.target.value)}
+              >
+                {voiceGroups.map((group) => (
+                  <optgroup key={group.label} label={group.label}>
+                    {group.options.map((opt) => (
+                      <option key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </option>
+                    ))}
+                  </optgroup>
+                ))}
+              </select>
+            </SelectShell>
           </div>
         </div>
 
         {/* Connect row */}
-        <div className="connect-row">
-          <div className="api-field">
-            <label htmlFor="apiKeyInput">
+        <div className="mt-5 flex flex-wrap items-end gap-3">
+          <div className="flex-1 basis-[280px]">
+            <FieldLabel
+              htmlFor="apiKeyInput"
+              linkHref="https://app.slng.ai"
+              linkText="Get API key →"
+            >
               API Key
-              <a
-                className="model-link"
-                href="https://app.slng.ai"
-                target="_blank"
-                rel="noopener"
-              >
-                Get API key &rarr;
-              </a>
-            </label>
-            <input
+            </FieldLabel>
+            <Input
               id="apiKeyInput"
               type="password"
               placeholder="Paste your SLNG API key"
@@ -683,27 +766,21 @@ export default function Home() {
               onChange={(e) => setApiKey(e.target.value)}
             />
           </div>
-          <div className="btn-group">
+          <div className="flex shrink-0 gap-2">
             {isWs && (
-              <button
-                type="button"
-                className={`secondary ${isConnected ? "" : ""}`}
-                onClick={handleConnect}
-              >
+              <Button type="button" variant="secondary" onClick={handleConnect}>
                 {isConnected ? "Disconnect" : "Connect"}
-              </button>
+              </Button>
             )}
-            <button
-              type="button"
-              className={`hero-button ${isBusy ? "is-loading" : ""} ${
-                isSendDisabled ? "is-disabled" : ""
-              }`}
-              onClick={handleSend}
-              disabled={isSendDisabled}
-            >
-              <span className="pulse" aria-hidden="true"></span>
+            <Button type="button" onClick={handleSend} disabled={isSendDisabled}>
+              {!isSendDisabled && (
+                <span
+                  aria-hidden="true"
+                  className="h-2.5 w-2.5 rounded-full bg-brand-yellow animate-slng-pulse"
+                />
+              )}
               {isBusy ? "Generating..." : "Say it"}
-            </button>
+            </Button>
           </div>
         </div>
 
@@ -717,8 +794,8 @@ export default function Home() {
 
         {/* REST: audio player */}
         {!isWs && (
-          <div className="audio-wrap">
-            <audio ref={audioRef} controls />
+          <div className="mt-4">
+            <audio ref={audioRef} controls className="w-full" />
           </div>
         )}
 
@@ -734,9 +811,9 @@ export default function Home() {
         <LogConsole entries={entries} onClear={clearLog} />
 
         {/* How to implement — mode-aware */}
-        <details>
-          <summary>How to implement</summary>
-          <div className="code-samples">
+        <details className={detailsClass}>
+          <summary className={summaryClass}>How to implement</summary>
+          <div className="mt-3 grid grid-cols-1 gap-3.5 md:grid-cols-2">
             {!isWs && (
               <>
                 <CodeBlock
@@ -849,90 +926,104 @@ ws.onmessage = (event) => {
 
         {/* Advanced settings (WS only) */}
         {isWs && (
-          <details>
-            <summary>Advanced settings</summary>
-            <div className="row" style={{ marginTop: 12 }}>
-              <div style={{ flex: 1 }}>
-                <label htmlFor="wsUrlInput">WebSocket URL</label>
-                <input
+          <details className={detailsClass}>
+            <summary className={summaryClass}>Advanced settings</summary>
+            <div className="mt-3 flex flex-wrap items-end gap-3">
+              <div className="flex-1 basis-[280px]">
+                <Label htmlFor="wsUrlInput" className="mb-2 block">
+                  WebSocket URL
+                </Label>
+                <Input
                   id="wsUrlInput"
                   type="text"
                   value={wsUrl}
                   onChange={(e) => setWsUrl(e.target.value)}
                 />
               </div>
-              <div style={{ flex: "0 0 200px", alignSelf: "flex-end" }}>
-                <label htmlFor="urlPattern">URL pattern</label>
-                <select
-                  id="urlPattern"
-                  value={useDirectUrl ? "direct" : "bridge"}
-                  onChange={(e) => setUseDirectUrl(e.target.value === "direct")}
-                >
-                  <option value="bridge">Bridge (/v1/bridges/unmute/tts/)</option>
-                  <option value="direct">Direct (/v1/tts/)</option>
-                </select>
+              <div className="basis-[200px]">
+                <Label htmlFor="urlPattern" className="mb-2 block">
+                  URL pattern
+                </Label>
+                <SelectShell>
+                  <select
+                    id="urlPattern"
+                    className={selectClass}
+                    value={useDirectUrl ? "direct" : "bridge"}
+                    onChange={(e) => setUseDirectUrl(e.target.value === "direct")}
+                  >
+                    <option value="bridge">Bridge (/v1/bridges/unmute/tts/)</option>
+                    <option value="direct">Direct (/v1/tts/)</option>
+                  </select>
+                </SelectShell>
               </div>
             </div>
 
-            <div className="row">
-              <div>
-                <label htmlFor="proxyUrlInput">Proxy WebSocket URL</label>
-                <input
+            <div className="mt-3 flex flex-wrap items-end gap-3">
+              <div className="flex-1 basis-[280px]">
+                <Label htmlFor="proxyUrlInput" className="mb-2 block">
+                  Proxy WebSocket URL
+                </Label>
+                <Input
                   id="proxyUrlInput"
                   type="text"
                   value={proxyUrl}
                   onChange={(e) => setProxyUrl(e.target.value)}
                 />
               </div>
-              <div style={{ flex: "0 0 180px", alignSelf: "flex-end" }}>
-                <label
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 8,
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={useProxy}
-                    onChange={(e) => setUseProxy(e.target.checked)}
-                  />
-                  Use proxy
-                </label>
-              </div>
+              <label className="flex h-10 items-center gap-2 text-sm">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 accent-primary"
+                  checked={useProxy}
+                  onChange={(e) => setUseProxy(e.target.checked)}
+                />
+                Use proxy
+              </label>
             </div>
 
-            <div className="row">
-              <div>
-                <label htmlFor="payloadMode">Payload mode</label>
-                <select
-                  id="payloadMode"
-                  value={payloadMode}
-                  onChange={(e) =>
-                    setPayloadMode(e.target.value as "text" | "custom")
-                  }
-                >
-                  <option value="text">{`{"text":"..."}`}</option>
-                  <option value="custom">Raw JSON (below)</option>
-                </select>
+            <div className="mt-3 flex flex-wrap gap-3">
+              <div className="flex-1 basis-[180px]">
+                <Label htmlFor="payloadMode" className="mb-2 block">
+                  Payload mode
+                </Label>
+                <SelectShell>
+                  <select
+                    id="payloadMode"
+                    className={selectClass}
+                    value={payloadMode}
+                    onChange={(e) =>
+                      setPayloadMode(e.target.value as "text" | "custom")
+                    }
+                  >
+                    <option value="text">{`{"text":"..."}`}</option>
+                    <option value="custom">Raw JSON (below)</option>
+                  </select>
+                </SelectShell>
               </div>
-              <div>
-                <label htmlFor="audioFormat">Audio format</label>
-                <select
-                  id="audioFormat"
-                  value={audioFormat}
-                  onChange={(e) =>
-                    setAudioFormat(e.target.value as AudioFormat)
-                  }
-                >
-                  <option value="mp3">MP3</option>
-                  <option value="wav">WAV</option>
-                  <option value="linear16">Linear16 (PCM)</option>
-                </select>
+              <div className="flex-1 basis-[180px]">
+                <Label htmlFor="audioFormat" className="mb-2 block">
+                  Audio format
+                </Label>
+                <SelectShell>
+                  <select
+                    id="audioFormat"
+                    className={selectClass}
+                    value={audioFormat}
+                    onChange={(e) =>
+                      setAudioFormat(e.target.value as AudioFormat)
+                    }
+                  >
+                    <option value="mp3">MP3</option>
+                    <option value="wav">WAV</option>
+                    <option value="linear16">Linear16 (PCM)</option>
+                  </select>
+                </SelectShell>
               </div>
-              <div>
-                <label htmlFor="sampleRateInput">Sample rate (PCM)</label>
-                <input
+              <div className="flex-1 basis-[180px]">
+                <Label htmlFor="sampleRateInput" className="mb-2 block">
+                  Sample rate (PCM)
+                </Label>
+                <Input
                   id="sampleRateInput"
                   type="text"
                   value={sampleRate}
@@ -942,41 +1033,34 @@ ws.onmessage = (event) => {
               </div>
             </div>
 
-            <label htmlFor="customPayload" style={{ marginTop: 12 }}>
+            <Label htmlFor="customPayload" className="mb-2 mt-3 block">
               Custom JSON payload
-            </label>
-            <textarea
+            </Label>
+            <Textarea
               id="customPayload"
+              className="font-mono"
               rows={4}
               spellCheck={false}
               value={customPayload}
               onChange={(e) => setCustomPayload(e.target.value)}
             />
 
-            <div className="row">
-              <div style={{ flex: "0 0 180px", alignSelf: "flex-end" }}>
-                <label
-                  style={{
-                    display: "flex",
-                    alignItems: "center",
-                    gap: 8,
-                  }}
-                >
-                  <input
-                    type="checkbox"
-                    checked={useCustomInit}
-                    onChange={(e) => setUseCustomInit(e.target.checked)}
-                  />
-                  Use custom init
-                </label>
-              </div>
-            </div>
-
-            <label htmlFor="customInitPayload" style={{ marginTop: 12 }}>
-              Custom init JSON
+            <label className="mt-3 flex items-center gap-2 text-sm">
+              <input
+                type="checkbox"
+                className="h-4 w-4 accent-primary"
+                checked={useCustomInit}
+                onChange={(e) => setUseCustomInit(e.target.checked)}
+              />
+              Use custom init
             </label>
-            <textarea
+
+            <Label htmlFor="customInitPayload" className="mb-2 mt-3 block">
+              Custom init JSON
+            </Label>
+            <Textarea
               id="customInitPayload"
+              className="font-mono"
               rows={4}
               spellCheck={false}
               value={customInitPayload}
@@ -984,12 +1068,13 @@ ws.onmessage = (event) => {
             />
           </details>
         )}
+      </Card>
 
-      </div>
-
-      <footer className="page-footer">
-        <div className="footer-stack">
-          <p className="h100-saans-bold">Unmuted.</p>
+      <footer className="flex flex-col items-center gap-4 border-t border-border pt-6 text-center text-sm text-muted-foreground">
+        <div className="flex flex-col items-center gap-4">
+          <p className="m-0 text-5xl font-extrabold tracking-tight text-foreground md:text-6xl">
+            Unmuted.
+          </p>
           <a href="https://slng.ai" target="_blank" rel="noopener">
             <img
               alt="SLNG"
@@ -1003,7 +1088,7 @@ ws.onmessage = (event) => {
           </a>
         </div>
         <a
-          className="footer-link"
+          className="font-semibold text-foreground hover:underline"
           href="https://app.slng.ai"
           target="_blank"
           rel="noopener"

--- a/slng-tts-next/package-lock.json
+++ b/slng-tts-next/package-lock.json
@@ -8,21 +8,43 @@
       "name": "slng-tts-next",
       "version": "0.1.0",
       "dependencies": {
+        "@radix-ui/react-label": "^2.1.8",
+        "@radix-ui/react-slot": "^1.2.4",
+        "@radix-ui/react-tabs": "^1.1.13",
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.553.0",
         "next": "16.1.2",
         "prism-react-renderer": "^2.4.1",
         "react": "19.2.3",
-        "react-dom": "19.2.3"
+        "react-dom": "19.2.3",
+        "tailwind-merge": "^3.4.0"
       },
       "devDependencies": {
+        "@tailwindcss/postcss": "^4.1.17",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@types/ws": "^8.18.1",
         "eslint": "^9",
         "eslint-config-next": "16.1.2",
+        "tailwindcss": "^4.1.17",
         "tsx": "^4.21.0",
         "typescript": "^5",
         "ws": "^8.19.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1657,6 +1679,316 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.10.tgz",
+      "integrity": "sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-label": {
+      "version": "2.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.10.tgz",
+      "integrity": "sha512-ib0zvq2ZsAqKm5tRnqGJn3vOxSgIts5ToxsXT0q1S/GfLD1Zj7UOEnkw8u2w6sRmn47djpQWuSU1DCL1R29/yw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.6"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.6.tgz",
+      "integrity": "sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.3.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.13.tgz",
+      "integrity": "sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.10",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.3.0.tgz",
+      "integrity": "sha512-MojKku4U/miO8Av4Dkb+ctMAQx7JmY96LmtDQlAarCRtd7rN52QCSzBF+XAvr5S6coSVj9HEPBgHAHKEJVk/WA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.15.tgz",
+      "integrity": "sha512-kxc9gI6/HfcU4nfMMVS3AmQK414kbU1IE6UCJmMmxjhO3cRPXOyYnmvyKD+ODt7q56nRq9l7Wovi6uaGwKgMlg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.6",
+        "@radix-ui/react-roving-focus": "1.1.13",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1671,6 +2003,318 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.1.tgz",
+      "integrity": "sha512-6NDaqRoAMSXD1mr/RXu0HBvNE9a2n5tHPsxu9XHLws8o4Twes5rBM2205SUUiJ9goAtadrN6xTGX0UDEwp/N4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.1.tgz",
+      "integrity": "sha512-yVPyo8RNkabVr3O2EhHEE0Rewu7YKzc1DhIqfL46LKveFrmu9XbDazNOJY7/GRuvw1h6u3utWnR29H/p5JPlgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.1",
+        "@tailwindcss/oxide-darwin-x64": "4.3.1",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.1",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.1",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.1",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.1",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.1",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.1.tgz",
+      "integrity": "sha512-SVlyf61g374l5cHyg8x9kf5xmLcOaxvOTsbsqDnSsDJaKOEFZ7GCvi84VAVGpxojYOs1+3K6M0UjXfqPU8vmOQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.1.tgz",
+      "integrity": "sha512-hVnWLwv+e/l7c4WKyVtHVrIPvYdqWHjRB3MDIqARynzFtnQg85kmQEFCbV9Ja0VVx4xXTIiDWY60Y7iz/iNoDA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.1.tgz",
+      "integrity": "sha512-Cf7abu0WVgbhU7ANgPUnSAvm7nCvMweusHb8FnaHlLfv/Caq4GYaEZg7ZImzzmjx4lIAfuS8q+eLIS7A7IzxIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.1.tgz",
+      "integrity": "sha512-ZZqzX2Y+GXtXXfqSfpJhDm60OoZfvLHLCgm+J7NVqgHHJjG/m9ugZI77RwTsVd4fnBJuCFP6Ae6kTJb71UdS8g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.1.tgz",
+      "integrity": "sha512-/Ah/xik0LaMYfv9DZ0S/t4pBlBNYOcqtRwusjgovHkvT8ixueWCLyJjsaF5kQIckjb4IT8Q6K6p/iPmZMixYgg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.1.tgz",
+      "integrity": "sha512-gqdFoVJlw444GvpnheZLHmvTzSxI/cOUUh2KSNejQjTcYkW062SVD+En0rUgD+QV91bz1XGIGtt1HJd48xUGbQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.1.tgz",
+      "integrity": "sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.1.tgz",
+      "integrity": "sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.1.tgz",
+      "integrity": "sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.1.tgz",
+      "integrity": "sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.1.tgz",
+      "integrity": "sha512-aiNvSq9BsVk8V513lDKlrCFAgf8qBMPZTpgEhInL+NwQqs97mYmupVMrPrgBBSL8Pv/0zXu9MrMF9rMun1ZeNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.1.tgz",
+      "integrity": "sha512-xDEyu1rg290472FEGaKHnzyDyh5QH+AlWvsU5hMoMtPpzmKlRI0jaYKCgSHDYtaQWZOYbMaduSyCwFwY4n1HmA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.1.tgz",
+      "integrity": "sha512-dNJuNbdEJT/SWRuXTYP1WSamelsz3ztkUsdtWQPjrexysrTpaEPM40P/71knXiXLYEojqPOEGitVLLpPMS5T6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.1",
+        "@tailwindcss/oxide": "4.3.1",
+        "postcss": "8.5.15",
+        "tailwindcss": "4.3.1"
+      }
+    },
+    "node_modules/@tailwindcss/postcss/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -1725,7 +2369,7 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.8.tgz",
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1735,7 +2379,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -2746,6 +3390,18 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -2814,7 +3470,7 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -2943,8 +3599,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -2990,6 +3646,20 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.1",
@@ -4000,6 +4670,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -4610,6 +5287,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -4737,6 +5424,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -4781,6 +5741,25 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.553.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.553.0.tgz",
+      "integrity": "sha512-BRgX5zrWmNy/lkVAe0dXBgd7XQdZ3HTf+Hwe3c9WK6dqgnj9h+hxV+MDncM88xDWlCq27+TKvHGE70ViODNILw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -4848,9 +5827,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -5940,6 +6919,37 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.1.tgz",
+      "integrity": "sha512-hk+TB1m+K8CYNrP6rjQaq/Y+4Zylwpa87mLYBKCunwnnQ9p+fHb7kmSfGqyEJoxF/O6CDyABWVFEafNSYKll+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
       }
     },
     "node_modules/tinyglobby": {

--- a/slng-tts-next/package.json
+++ b/slng-tts-next/package.json
@@ -10,18 +10,27 @@
     "proxy": "tsx scripts/ws-proxy.ts"
   },
   "dependencies": {
+    "@radix-ui/react-label": "^2.1.8",
+    "@radix-ui/react-slot": "^1.2.4",
+    "@radix-ui/react-tabs": "^1.1.13",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.553.0",
     "next": "16.1.2",
     "prism-react-renderer": "^2.4.1",
     "react": "19.2.3",
-    "react-dom": "19.2.3"
+    "react-dom": "19.2.3",
+    "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {
+    "@tailwindcss/postcss": "^4.1.17",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@types/ws": "^8.18.1",
     "eslint": "^9",
     "eslint-config-next": "16.1.2",
+    "tailwindcss": "^4.1.17",
     "tsx": "^4.21.0",
     "typescript": "^5",
     "ws": "^8.19.0"

--- a/slng-tts-next/postcss.config.mjs
+++ b/slng-tts-next/postcss.config.mjs
@@ -1,0 +1,7 @@
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;


### PR DESCRIPTION
## What

Restyles `slng-tts-next` and `slng-stt-next` to match the SLNG product design system (`slng-ai/frontend`): Tailwind v4 + shadcn/ui + the Figma color/typography tokens.

## How

- **Tailwind v4 + PostCSS** added to both apps, with the canonical `@theme` tokens copied from `slng-ai/frontend` (radius `0.375rem`, ink focus ring, neutral paper accent; yellow/blue kept as sparse `--brand-*` tokens). Fonts: **Geist** sans/mono (no Saans, per request).
- **Vendored shadcn primitives** (Button, Card, Input, Textarea, Label, Badge, Tabs + `cn`) into each app's `app/components/ui/` — copy-in so each example stays standalone (no private package dependency).
- **Pages + components rewritten** to the design system:
  - Segmented toggles (REST/WebSocket; WebSocket/HTTP; Microphone/File/URL) → `Tabs`.
  - Bespoke buttons → `Button`; styled card → `Card`; password/url/text fields → `Input`; `Textarea`, `Label`.
  - Native `<select>` kept (preserves `<optgroup>` grouping for models/voices/languages) but restyled to match the shadcn Select trigger with a chevron.
  - `StatusBar`, `LogConsole`, `CodeBlock`, `WaveformCanvas`, `TranscriptDisplay`, file dropzone all retokenized (lucide icons, brand-yellow waveform).

## Bug fix (TTS)

The WebSocket waveform froze on `audio_end` while buffered PCM was still playing. It now keeps animating until scheduled playback actually finishes (`getPlaybackRemainingMs()` on the Web Audio hook), guarded so a stale timer can't kill a fresh animation.

## Verification

- Both apps `tsc --noEmit` clean.
- Ran both via `next dev`, served 200, Tailwind compiled, no runtime errors. Screenshots confirm both match the design system and each other.

## Notes

- Native `<select>` used instead of the Radix Select (keeps optgroups + simpler example code); easy to swap to full Radix Select for exact parity.
- Dark-mode tokens are wired (`.dark` class) but there's no in-app toggle, so both stay light — matching prior behavior.
- A full `next build` trips on a pre-existing `useWebSocket.ts` lint error unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)